### PR TITLE
fix: prevent sendAll to send negative amounts

### DIFF
--- a/internal/interpreter/interpreter.go
+++ b/internal/interpreter/interpreter.go
@@ -443,7 +443,7 @@ func (s *programState) sendAllToAccount(accountLiteral parser.ValueExpr, ovedraf
 	balance := s.getCachedBalance(*account, s.CurrentAsset)
 
 	// we sent balance+overdraft
-	sentAmt := new(big.Int).Add(balance, ovedraft)
+	sentAmt := utils.MaxBigInt(new(big.Int).Add(balance, ovedraft), big.NewInt(0))
 	s.pushSender(*account, sentAmt)
 	return sentAmt, nil
 }

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -20,3 +20,15 @@ func MinBigInt(a *big.Int, b *big.Int) *big.Int {
 
 	return &min
 }
+
+func MaxBigInt(a *big.Int, b *big.Int) *big.Int {
+	var max big.Int
+
+	if a.Cmp(b) == 1 {
+		max.Set(a)
+	} else {
+		max.Set(b)
+	}
+
+	return &max
+}


### PR DESCRIPTION
This PR fixes a bug caused numscript to send a negative amount when the balance amount was negative
```
// say @alice's USD/2 balance is [USD/2 -100]
send [USD/2 *] (
  source = @alice
  destination = @bob
)
```
correct posting: `@alice [USD/2 0]-> @bob (trimmed)`
before the fix: `@alice [USD/2 -100]-> @bob (trimmed)`