### PR TITLE
breaking: pass flags as slice instead of many args

### DIFF
--- a/internal/flags/flags.go
+++ b/internal/flags/flags.go
@@ -8,3 +8,10 @@ const (
 	ExperimentalAccountInterpolationFlag     FeatureFlag = "experimental-account-interpolation"
 	ExperimentalMidScriptFunctionCall        FeatureFlag = "experimental-mid-script-function-call"
 )
+
+var AllFlags []string = []string{
+	ExperimentalOverdraftFunctionFeatureFlag,
+	ExperimentalOneofFeatureFlag,
+	ExperimentalAccountInterpolationFlag,
+	ExperimentalMidScriptFunctionCall,
+}


### PR DESCRIPTION
As we're creating more and more experimental features, it's becoming annoying to have a cli arg for each flag (Don't worry, we'll start actually making them stable soon - probably as numscript interpreter itself becomes stable)
So we'll pass them as a slice instead

Note: even though we created a way to "pass" flags via comment annotation  with this PR https://github.com/formancehq/numscript/pull/51 , the PR's idea is that those comments are meant for static analysis (that is, "numscript check" and the vscode extension). During the execution phase, those comments are treated as comments - that is, ignored entirely
I get that this might be considered a bit confusing and inconsistent, so this decision is opened for feedback. We can just use the `// @ feature_flag my-flag` comments as the sole feature flag mechanism instead
One reason why that's not done yet, is that if we were to rely on those for execution too, we'd have to define more precisely the behaviour; for example:
* defining the grammar more precisely (e.g. is `// @ feature_flag my-flag and other trailing random text` a valid annotation? )
* where are those comments legal? can they be at the end of the file? Can they be not at the start of the line?
Those issues are less serious if the annotations are just for vscode diagnostics, but if users were to use them to run actual code, such a flaky mechanism wouldn't be an idea API: it'd probably be better to pass flags explicitly to the cli, or the ledger config, or the function call.

To recap:
* static analysis => flags as comments
* interpreter runtime => flags passed explicitly (comments are ignored)