### PR TITLE
fix: fix padding of colored headers

### DIFF
--- a/internal/interpreter/__snapshots__/balances_test.snap
+++ b/internal/interpreter/__snapshots__/balances_test.snap
@@ -1,6 +1,6 @@
 
 [TestPrettyPrintBalance - 1]
-| [36mAccount[0m | [36mAsset[0m | [36mBalance[0m |
+| [36mAccount[0m | [36mAsset   [0m | [36mBalance[0m |
 | alice   | EUR/2    | 1       |
 | alice   | USD/1234 | 999999  |
 | bob     | BTC      | 3       |

--- a/internal/utils/__snapshots__/pretty_csv_test.snap
+++ b/internal/utils/__snapshots__/pretty_csv_test.snap
@@ -1,13 +1,13 @@
 
 [TestPrettyCsv - 1]
-| [36mAccount[0m | [36mAsset[0m | [36mBalance[0m |
+| [36mAccount[0m | [36mAsset   [0m | [36mBalance[0m |
 | alice   | EUR/2    | 1       |
 | alice   | USD/1234 | 999999  |
 | bob     | BTC      | 3       |
 ---
 
 [TestPrettyCsvMap - 1]
-| [36mName[0m           | [36mValue[0m |
+| [36mName                   [0m | [36mValue[0m |
 | a                       | 0     |
 | b                       | 12345 |
 | very-very-very-long-key |       |

--- a/internal/utils/pretty_csv.go
+++ b/internal/utils/pretty_csv.go
@@ -48,10 +48,11 @@ func CsvPretty(
 	{
 		var partialRow []string
 		for index, fieldName := range header {
-			partialRow = append(partialRow, fmt.Sprintf("| %-*s ",
+			paddedHeader := fmt.Sprintf("%-*s",
 				maxLengths[index],
-				ansi.ColorCyan(fieldName),
-			))
+				fieldName,
+			)
+			partialRow = append(partialRow, fmt.Sprintf("| %s ", ansi.ColorCyan(paddedHeader)))
 		}
 		partialRow = append(partialRow, "|")
 		allRows = append(allRows, strings.Join(partialRow, ""))


### PR DESCRIPTION
fix error in padding when pretty-printing tabular data (e.g. balances outputs)