### PR TITLE
fix: save-all when balance is negative

### DIFF
--- a/internal/interpreter/interpreter.go
+++ b/internal/interpreter/interpreter.go
@@ -395,7 +395,9 @@ func (st *programState) runSaveStatement(saveStatement parser.SaveStatement) Int
 	balance := st.CachedBalances.fetchBalance(*account, *asset, "")
 
 	if amt == nil {
-		balance.Set(big.NewInt(0))
+		if balance.Sign() > 0 {
+			balance.Set(big.NewInt(0))
+		}
 	} else {
 		// Do not allow negative saves
 		if amt.Cmp(big.NewInt(0)) == -1 {

--- a/internal/interpreter/testdata/script-tests/save/save-from-account__save-all-negative-balance.num
+++ b/internal/interpreter/testdata/script-tests/save/save-from-account__save-all-negative-balance.num
@@ -1,0 +1,6 @@
+save [USD *] from @alice
+
+send [USD 10] (
+  source = @alice allowing overdraft up to [USD 30]
+  destination = @world
+)

--- a/internal/interpreter/testdata/script-tests/save/save-from-account__save-all-negative-balance.num.specs.json
+++ b/internal/interpreter/testdata/script-tests/save/save-from-account__save-all-negative-balance.num.specs.json
@@ -1,0 +1,13 @@
+{
+  "testCases": [
+    {
+      "it": "-",
+      "balances": {
+        "alice": {
+          "USD": -100
+        }
+      },
+      "expect.error.missingFunds": true
+    }
+  ]
+}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes save-all so negative balances are not reset to zero. This prevents incorrect fund availability and correctly triggers missingFunds for overdrawn accounts.

- **Bug Fixes**
  - Only zero out balance on save-all when the balance is positive.
  - Added a script test for a negative USD balance that expects missingFunds.

<sup>Written for commit 23909b208a7f253e174b95404468b07198768562. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

