### PR TITLE
refactor: rename funds stack

### DIFF
--- a/internal/interpreter/funds_queue.go
+++ b/internal/interpreter/funds_queue.go
@@ -176,13 +176,13 @@ func (s *fundsQueue) Pull(requiredAmount *big.Int, color *string) []Sender {
 
 // Clone the queue so that you can safely mutate one without mutating the other
 func (s fundsQueue) Clone() fundsQueue {
-	fs := newFundsQueue(nil)
+	fq := newFundsQueue(nil)
 
 	senders := s.senders
 	for senders != nil {
-		fs.Push(senders.Head)
+		fq.Push(senders.Head)
 		senders = senders.Tail
 	}
 
-	return fs
+	return fq
 }

--- a/internal/interpreter/funds_queue_test.go
+++ b/internal/interpreter/funds_queue_test.go
@@ -175,13 +175,13 @@ func TestPullColoredComplex(t *testing.T) {
 
 func TestClone(t *testing.T) {
 
-	fs := newFundsQueue([]Sender{
+	fq := newFundsQueue([]Sender{
 		{"s1", big.NewInt(10), ""},
 	})
 
-	cloned := fs.Clone()
+	cloned := fq.Clone()
 
-	fs.PullAll()
+	fq.PullAll()
 
 	require.Equal(t, []Sender{
 		{"s1", big.NewInt(10), ""},

--- a/internal/interpreter/interpreter.go
+++ b/internal/interpreter/interpreter.go
@@ -729,11 +729,11 @@ func (s *programState) trySendingToAccount(accountLiteral parser.ValueExpr, amou
 }
 
 func (s *programState) cloneState() func() {
-	fsBackup := s.fundsQueue.Clone()
+	fqBackup := s.fundsQueue.Clone()
 	balancesBackup := s.CachedBalances.DeepClone()
 
 	return func() {
-		s.fundsQueue = fsBackup
+		s.fundsQueue = fqBackup
 		s.CachedBalances = balancesBackup
 	}
 }


### PR DESCRIPTION
Fix incorrect naming of the FIFO data structure that holds the funds
credits @Azorlogh  (https://github.com/formancehq/numscript/pull/100)
