### PR TITLE
fix: make .envrc compatible with nix-direnv, allowing shell caching

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,1 +1,1 @@
-use flake --impure
+use flake . --impure


### PR DESCRIPTION
## Summary
- Update `use flake --impure` to `use flake . --impure` in `.envrc`
- This makes the flake command compatible with [nix-direnv](https://github.com/nix-community/nix-direnv), which requires an explicit flake reference to enable shell caching
- Without the `.` argument, nix-direnv falls back to `nix-shell` behavior and cannot cache the dev shell

## Test plan
- [ ] Verify `direnv allow` works correctly with the updated `.envrc`
- [ ] Confirm nix-direnv caches the shell properly

🤖 Generated with [Claude Code](https://claude.com/claude-code)