### PR TITLE
fix: fix potential overflow

### DIFF
--- a/internal/parser/__snapshots__/parser_test.snap
+++ b/internal/parser/__snapshots__/parser_test.snap
@@ -301,7 +301,7 @@ parser.Program{
                                     neg: false,
                                     abs: {0x2a},
                                 },
-                                FloatingDigits: 0x0,
+                                FloatingDigits: 0,
                             },
                         },
                         From: &parser.SourceAccount{
@@ -467,7 +467,7 @@ parser.Program{
                                     neg: false,
                                     abs: {0xf2},
                                 },
-                                FloatingDigits: 0x2,
+                                FloatingDigits: 2,
                             },
                         },
                         From: &parser.SourceAccount{

--- a/internal/parser/ast.go
+++ b/internal/parser/ast.go
@@ -65,7 +65,7 @@ type (
 	PercentageLiteral struct {
 		Range
 		Amount         *big.Int
-		FloatingDigits uint16
+		FloatingDigits int
 	}
 
 	Variable struct {

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -273,7 +273,7 @@ func parseSource(sourceCtx antlrParser.ISourceContext) Source {
 }
 
 // Returns (a, b) representing a/(10^b)
-func ParsePercentageRatio(source string) (*big.Int, uint16, error) {
+func ParsePercentageRatio(source string) (*big.Int, int, error) {
 	source = strings.TrimSuffix(source, "%")
 
 	scale := 0
@@ -287,7 +287,7 @@ func ParsePercentageRatio(source string) (*big.Int, uint16, error) {
 		return nil, 0, fmt.Errorf("unexpected invalid string literal: %s", source)
 	}
 
-	return num, uint16(scale), nil
+	return num, scale, nil
 }
 
 func parsePercentageRatio(source string, range_ Range) *PercentageLiteral {

--- a/internal/parser/parser_test.go
+++ b/internal/parser/parser_test.go
@@ -312,13 +312,13 @@ func TestParseFloatingPerc(t *testing.T) {
 		require.NoError(t, err)
 		// (123/100)%
 		require.Equal(t, big.NewInt(123), num)
-		require.Equal(t, uint16(2), fl)
+		require.Equal(t, 2, fl)
 	})
 	t.Run("leading zero", func(t *testing.T) {
 		num, fl, err := parser.ParsePercentageRatio("0.23%")
 		require.NoError(t, err)
 		require.Equal(t, big.NewInt(23), num)
-		require.Equal(t, uint16(2), fl)
+		require.Equal(t, 2, fl)
 		// (23/100)%
 	})
 
@@ -326,7 +326,7 @@ func TestParseFloatingPerc(t *testing.T) {
 		num, fl, err := parser.ParsePercentageRatio("0.01%")
 		require.NoError(t, err)
 		require.Equal(t, big.NewInt(1), num)
-		require.Equal(t, uint16(2), fl)
+		require.Equal(t, 2, fl)
 		// (1/100)%
 	})
 
@@ -334,7 +334,7 @@ func TestParseFloatingPerc(t *testing.T) {
 		num, fl, err := parser.ParsePercentageRatio("0.019%")
 		require.NoError(t, err)
 		require.Equal(t, big.NewInt(19), num)
-		require.Equal(t, uint16(3), fl)
+		require.Equal(t, 3, fl)
 		// (19/1000)%
 	})
 
@@ -342,7 +342,7 @@ func TestParseFloatingPerc(t *testing.T) {
 		num, fl, err := parser.ParsePercentageRatio("1.20%")
 		require.NoError(t, err)
 		require.Equal(t, big.NewInt(120), num)
-		require.Equal(t, uint16(2), fl)
+		require.Equal(t, 2, fl)
 		// (120/100)%
 	})
 
@@ -350,28 +350,28 @@ func TestParseFloatingPerc(t *testing.T) {
 		num, fl, err := parser.ParsePercentageRatio("0%")
 		require.NoError(t, err)
 		require.Equal(t, big.NewInt(0), num)
-		require.Equal(t, uint16(0), fl)
+		require.Equal(t, 0, fl)
 	})
 
 	t.Run("zero point zero", func(t *testing.T) {
 		num, fl, err := parser.ParsePercentageRatio("0.0%")
 		require.NoError(t, err)
 		require.Equal(t, big.NewInt(0), num)
-		require.Equal(t, uint16(1), fl) // 0 / 10^1 is still 0
+		require.Equal(t, 1, fl) // 0 / 10^1 is still 0
 	})
 
 	t.Run("leading zeros in integer part", func(t *testing.T) {
 		num, fl, err := parser.ParsePercentageRatio("007.5%")
 		require.NoError(t, err)
 		require.Equal(t, big.NewInt(75), num)
-		require.Equal(t, uint16(1), fl)
+		require.Equal(t, 1, fl)
 	})
 
 	t.Run("purely fractional small number", func(t *testing.T) {
 		num, fl, err := parser.ParsePercentageRatio("0.00009%")
 		require.NoError(t, err)
 		require.Equal(t, big.NewInt(9), num)
-		require.Equal(t, uint16(5), fl)
+		require.Equal(t, 5, fl)
 	})
 
 }


### PR DESCRIPTION
Fixes https://github.com/formancehq/numscript/pull/129

As per specs, int is repr'd with at least 32bits. So we have ~2 billions digits that we can write in a numscript source code. Should be enough to avoid thinking about edge cases in case of integer overflow without adding further logic or tests and without having to document limitations