### PR TITLE
chore(ci): migrate from Shipfox to Namespace.so runners

### DIFF
--- a/.github/actions/default/action.yml
+++ b/.github/actions/default/action.yml
@@ -9,19 +9,11 @@ runs:
   steps:
     - name: Install Nix
       uses: cachix/install-nix-action@v31
-    - name: Cache dependencies
-      uses: nix-community/cache-nix-action@v7
-      with:
-        primary-key: nix-${{ runner.os }}-${{ hashFiles('**/flake.nix', '**/flake.lock') }}
-        restore-prefixes-first-match: nix-${{ runner.os }}-
     - name: Load dependencies
       shell: bash
       run: nix develop --install
-    - uses: actions/cache@v5
+    - uses: namespacelabs/nscloud-cache-action@v1
       with:
         path: |
           ~/.cache/go-build
           /tmp/go/pkg/mod/
-        key: ${{ runner.os }}-${{ github.job }}-go-${{ hashFiles('**/go.sum') }}
-        restore-keys: |
-          ${{ runner.os }}-${{ github.job }}-go-

--- a/.github/actions/env/action.yml
+++ b/.github/actions/env/action.yml
@@ -7,10 +7,8 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: Set up QEMU
-      uses: docker/setup-qemu-action@v4
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v4
+      uses: namespacelabs/nscloud-setup-buildx-action@v0
     - name: "Put back the git branch into git (Earthly uses it for tagging)"
       shell: bash
       run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,12 +25,12 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   Dirty:
-    runs-on: "shipfox-4vcpu-ubuntu-2404"
+    runs-on: "namespace-profile-linux-amd64-4vcpu"
     env:
       GOPATH: /tmp/go
       GOLANGCI_LINT_CACHE: /tmp/golangci-lint
     steps:
-      - uses: 'actions/checkout@v6'
+      - uses: 'namespacelabs/nscloud-checkout-action@v7'
         with:
           fetch-depth: 0
       - name: Setup Env
@@ -52,11 +52,11 @@ jobs:
           fi
 
   Tests:
-    runs-on: "shipfox-4vcpu-ubuntu-2404"
+    runs-on: "namespace-profile-linux-amd64-4vcpu"
     env:
       GOPATH: /tmp/go
     steps:
-      - uses: 'actions/checkout@v6'
+      - uses: 'namespacelabs/nscloud-checkout-action@v7'
         with:
           fetch-depth: 0
       - name: Setup Env
@@ -71,30 +71,26 @@ jobs:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
   GoReleaser:
-    runs-on: "shipfox-4vcpu-ubuntu-2404"
+    runs-on: "namespace-profile-linux-amd64-4vcpu"
     if: contains(github.event.pull_request.labels.*.name, 'build-images') || github.ref == 'refs/heads/main' || github.event_name == 'merge_group'
     needs:
       - Dirty
     steps:
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v4
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: namespacelabs/nscloud-setup-buildx-action@v0
       - uses: earthly/actions-setup@v1
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           version: "latest"
-      - uses: 'actions/checkout@v6'
+      - uses: 'namespacelabs/nscloud-checkout-action@v7'
         with:
           fetch-depth: 0
       - name: Setup Env
         uses: ./.github/actions/default
         with:
           token: ${{ secrets.NUMARY_GITHUB_TOKEN }}
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v4
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: namespacelabs/nscloud-setup-buildx-action@v0
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v4
         with:

--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -8,19 +8,17 @@ permissions:
 
 jobs:
   GoReleaser:
-    runs-on: "shipfox-4vcpu-ubuntu-2404"
+    runs-on: "namespace-profile-linux-amd64-4vcpu"
     steps:
-      - uses: 'actions/checkout@v6'
+      - uses: 'namespacelabs/nscloud-checkout-action@v7'
         with:
           fetch-depth: 0
       - name: Setup Env
         uses: ./.github/actions/default
         with:
           token: ${{ secrets.NUMARY_GITHUB_TOKEN }}
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v4
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: namespacelabs/nscloud-setup-buildx-action@v0
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v4
         with:


### PR DESCRIPTION
## Summary

Migrate CI runners from Shipfox to Namespace.so as part of the org-wide CI infrastructure migration.

### Per-workflow changes
- `runs-on: shipfox-Xvcpu-ubuntu-2404` → `runs-on: namespace-profile-linux-amd64-Xvcpu`
- `actions/checkout@v6` → `namespacelabs/nscloud-checkout-action@v7` (git mirror caching, `filter: tree:0` → `dissociate: true`)
- `docker/setup-qemu-action` removed (Namespace builds AMD64+ARM64 natively without emulation)
- `docker/setup-buildx-action` → `namespacelabs/nscloud-setup-buildx-action@v0` (Remote Builders)

### Pattern A composite (`.github/actions/default/action.yml`)
- `nix-community/cache-nix-action@v7` → removed (incompatible with Namespace runner setup, see banking-bridge testing)
- `actions/cache@v5` → `namespacelabs/nscloud-cache-action@v1` (paths preserved)

### Validation
- Reference migration: formancehq/ledger#1336 (4 successful runs measured, GoReleaser validated with multi-arch native build)
- 4 banking-bridge PRs validated this exact patch flow

## Test plan
- [ ] CI passes on this PR
- [ ] No regression in build duration vs prior shipfox runs
- [ ] `GoReleaser` works (add `build-images` label if needed to trigger)