### PR TITLE
refactor: improve repr of account interp

### DIFF
--- a/internal/interpreter/evaluate_expr.go
+++ b/internal/interpreter/evaluate_expr.go
@@ -36,7 +36,7 @@ func (st *programState) evaluateExpr(expr parser.ValueExpr) (Value, InterpreterE
 				parts = append(parts, strValue)
 			}
 		}
-		name := strings.Join(parts, ":")
+		name := strings.Join(parts, "")
 		return NewAccountAddress(name)
 
 	case *parser.StringLiteral:

--- a/internal/parser/__snapshots__/parser_test.snap
+++ b/internal/parser/__snapshots__/parser_test.snap
@@ -2246,6 +2246,7 @@ parser.Program{
                                     },
                                     Parts: {
                                         parser.AccountTextPart{Name:"player"},
+                                        parser.AccountTextPart{Name:":"},
                                         parser.AccountTextPart{Name:"1"},
                                     },
                                 },
@@ -3243,7 +3244,9 @@ parser.Program{
                     },
                     Parts: {
                         parser.AccountTextPart{Name:"abc"},
+                        parser.AccountTextPart{Name:":"},
                         parser.AccountTextPart{Name:"cde"},
+                        parser.AccountTextPart{Name:":"},
                         &parser.Variable{
                             Range: parser.Range{
                                 Start: parser.Position{Character:21, Line:0},

--- a/internal/parser/ast.go
+++ b/internal/parser/ast.go
@@ -127,7 +127,7 @@ func (expr AccountInterpLiteral) String() string {
 			parts = append(parts, "$"+part.Name)
 		}
 	}
-	return strings.Join(parts, ":")
+	return strings.Join(parts, "")
 }
 
 // Source exprs

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -341,15 +341,21 @@ func parseValueExpr(valueExprCtx antlrParser.IValueExprContext) ValueExpr {
 		litRng := ctxToRange(valueExprCtx)
 
 		var parts []AccountNamePart
-		for _, accLit := range valueExprCtx.AllAccountLiteralPart() {
-			varPartText := accLit.GetText()
+		for _, accLit := range valueExprCtx.GetChildren() {
 			switch accLit := accLit.(type) {
 			case *antlrParser.AccountTextPartContext:
+				varPartText := accLit.GetText()
 				parts = append(parts, AccountTextPart{Name: varPartText})
 			case *antlrParser.AccountVarPartContext:
 				v := parseVarLiteral(accLit.VARIABLE_NAME_ACC().GetSymbol())
 				parts = append(parts, v)
+
+			case antlr.TerminalNode:
+				if accLit.GetSymbol().GetTokenType() == antlrParser.NumscriptParserCOLON {
+					parts = append(parts, AccountTextPart{Name: ":"})
+				}
 			}
+
 		}
 
 		return &AccountInterpLiteral{


### PR DESCRIPTION
Improve the representation of interpolated accounts, e.g. `@user:$id:pending`, so that we also keep the ":" parts in the AST.
This doesn't change the existing behaviour, nor the way it interacts with LSP (e.g. mouse hovering). But it keeps a more correct and lossless AST