### PR TITLE
fix(asset_scaling): match base asset exactly, not as a string prefix

### DIFF
--- a/internal/interpreter/asset_scaling.go
+++ b/internal/interpreter/asset_scaling.go
@@ -38,13 +38,18 @@ func getAssetScale(asset string) (string, int64) {
 	return asset, 0
 }
 
+// getAssets returns, for every precision scale found in `balance`, the amount
+// available for `baseAsset`. Match is exact on the base name: `USDT` and
+// `USD_RED` are NOT considered scaled forms of `USD`. Only the bare base name
+// and its `baseAsset/N` precision variants qualify.
 func getAssets(balance AccountBalance, baseAsset string) map[int64]*big.Int {
 	result := make(map[int64]*big.Int)
 	for asset, amount := range balance {
-		if strings.HasPrefix(asset, baseAsset) {
-			_, scale := getAssetScale(asset)
-			result[scale] = amount
+		if asset != baseAsset && !strings.HasPrefix(asset, baseAsset+"/") {
+			continue
 		}
+		_, scale := getAssetScale(asset)
+		result[scale] = amount
 	}
 	return result
 }


### PR DESCRIPTION
## Summary

Tightens `getAssets` (in `internal/interpreter/asset_scaling.go`) so an entry
belongs to the `baseAsset` scaling pool **iff** its key is exactly
`baseAsset` or has the form `baseAsset/N`. Drops the spurious matches
the parent test PR pins.

This PR is stacked on **#141** (the failing regression test). Merging
this flips `TestGetAssetsRejectsSpuriousPrefixMatches` from red to
green.

## Stack

| PR | What it does | Target |
| --- | --- | --- |
| [#141](https://github.com/formancehq/numscript/pull/141) | Failing regression test pinning the bug | `main` |
| **this PR (#140)** | Tightens `getAssets` exact-match | #141 branch |

## Diff vs the parent test branch

Single 5-line change in `getAssets`:

```diff
- if strings.HasPrefix(asset, baseAsset) {
-     _, scale := getAssetScale(asset)
-     result[scale] = amount
- }
+ if asset != baseAsset && !strings.HasPrefix(asset, baseAsset+"/") {
+     continue
+ }
+ _, scale := getAssetScale(asset)
+ result[scale] = amount
```

Plus a doc-comment on the function.

## Test plan

- [x] `TestGetAssetsRejectsSpuriousPrefixMatches` passes (red on #141, green here).
- [x] All other tests stay green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
