### PR TITLE
test(asset_scaling): pin getAssets prefix-match bug (failing)

### DIFF
--- a/internal/interpreter/asset_scaling_test.go
+++ b/internal/interpreter/asset_scaling_test.go
@@ -272,3 +272,49 @@ func TestUnboundedScalinHigherAssetTrimRemainder(t *testing.T) {
 		{3, big.NewInt(10)},
 	}, sol)
 }
+
+// getAssets must match a base asset exactly: assets that merely share the
+// base name as a string prefix (e.g. "USDT" or "USD_RED") are NOT scaled
+// forms of "USD" and must be ignored. Only the bare base and its
+// "base/N" precision variants belong in the scaling pool.
+//
+// Sub-tests are deliberately split so each is deterministic regardless of
+// Go's randomized map iteration order. A combined fixture is flaky:
+// `getAssets` keys its result map by precision alone, so when both
+// `USD/2 = 2` and `USD_RED/2 = 500` are present the buggy implementation
+// writes both to `result[2]`, and the final value depends on iteration
+// order — sometimes the correct one wins, sometimes the spurious one.
+func TestGetAssetsRejectsSpuriousPrefixMatches(t *testing.T) {
+	t.Run("USDT does not pollute USD pool", func(t *testing.T) {
+		balance := AccountBalance{
+			"USDT":   big.NewInt(100),
+			"USDT/2": big.NewInt(200),
+		}
+		got := getAssets(balance, "USD")
+		require.Empty(t, got, "USDT-prefixed entries must not be folded into USD")
+	})
+
+	t.Run("color-suffixed variants do not pollute USD pool", func(t *testing.T) {
+		balance := AccountBalance{
+			"USD_RED":   big.NewInt(50),
+			"USD_RED/2": big.NewInt(500),
+		}
+		got := getAssets(balance, "USD")
+		require.Empty(t, got, "USD_RED-prefixed entries must not be folded into USD")
+	})
+
+	t.Run("USD precision variants are picked up", func(t *testing.T) {
+		balance := AccountBalance{
+			"USD":   big.NewInt(1),
+			"USD/2": big.NewInt(2),
+			"USD/3": big.NewInt(3),
+		}
+		got := getAssets(balance, "USD")
+		require.Equal(t, map[int64]*big.Int{
+			0: big.NewInt(1),
+			2: big.NewInt(2),
+			3: big.NewInt(3),
+		}, got)
+	})
+
+}


### PR DESCRIPTION
## Summary

Failing regression test demonstrating a pre-existing bug in
`internal/interpreter/asset_scaling.go::getAssets`. CI is **intentionally
red** on this branch — see the stacked fix PR below.

`getAssets(balance, baseAsset)` uses `strings.HasPrefix(asset, baseAsset)`
to gather scaled variants of an asset. The match is too loose:

| Stored key | Should match `USD`? | Currently matches? |
| --- | --- | --- |
| `USD` | yes | ✅ |
| `USD/2` | yes | ✅ |
| `USDT` | **no** | ❌ |
| `USDT/2` | **no** | ❌ |
| `USD_RED` (color-suffix-encoded) | **no** | ❌ |
| `USD_RED/2` | **no** | ❌ |

Because the result map is keyed by precision scale only, an entry
like `USD_RED/2 = 500` silently overwrites the true `USD/2 = 2` value
in the scaling pool — corrupting any subsequent conversion. The result
is non-deterministic (last-write-wins on randomized map iteration), so
the failing test is structured as three deterministic sub-tests rather
than one composite assertion.

## Stack

| PR | What it does | Target |
| --- | --- | --- |
| **this PR (#141)** | Adds the failing regression test | `main` |
| [#140](https://github.com/formancehq/numscript/pull/140) | Tightens `getAssets` to exact base + `base/N` match | this branch |

Merging the fix flips the test green.

## Test plan

- [x] `TestGetAssetsRejectsSpuriousPrefixMatches` fails locally with
      sub-test failures for `USDT` and `USD_RED` prefix pollution.
- [x] All other tests stay green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
