### PR TITLE
fix(mcp_impl): validate JSON amounts as exact integers before big.Int conversion

### DIFF
--- a/internal/mcp_impl/handlers.go
+++ b/internal/mcp_impl/handlers.go
@@ -13,6 +13,11 @@ import (
 	"github.com/mark3labs/mcp-go/server"
 )
 
+// maxExactJSONInt is the largest integer that float64 can represent
+// without loss (2^53 - 1). JSON-decoded amounts past this magnitude have
+// already lost precision before reaching the handler, so we reject them.
+const maxExactJSONInt = float64(9_007_199_254_740_991)
+
 func parseBalancesJson(balancesRaw any) (interpreter.Balances, *mcp.CallToolResult) {
 	balances, ok := balancesRaw.(map[string]any)
 	if !ok {
@@ -33,11 +38,20 @@ func parseBalancesJson(balancesRaw any) (interpreter.Balances, *mcp.CallToolResu
 		for asset, amountRaw := range assets {
 			amount, ok := amountRaw.(float64)
 			if !ok {
-				return interpreter.Balances{}, mcp.NewToolResultError(fmt.Sprintf("Expected float for amount: %v", amountRaw))
+				return interpreter.Balances{}, mcp.NewToolResultError(fmt.Sprintf("Expected number for amount on %s/%s, got: <%#v>", account, asset, amountRaw))
 			}
 
-			n, _ := big.NewFloat(amount).Int(new(big.Int))
-			iBalances[account][asset] = n
+			// JSON numbers arrive here as float64. Reject anything that
+			// cannot be losslessly represented as an integer in float64
+			// precision: fractional values and magnitudes past 2^53 - 1.
+			// Silent truncation / rounding on a balance is not acceptable
+			// for a financial DSL — the caller should switch to a safer
+			// encoding when they need values outside the safe range.
+			if amount < -maxExactJSONInt || amount > maxExactJSONInt || amount != float64(int64(amount)) {
+				return interpreter.Balances{}, mcp.NewToolResultError(fmt.Sprintf("amount for %s/%s must be an exact integer in [-(2^53-1), 2^53-1], got: %v", account, asset, amount))
+			}
+
+			iBalances[account][asset] = big.NewInt(int64(amount))
 		}
 	}
 	return iBalances, nil


### PR DESCRIPTION
## Summary

Validates JSON amounts before converting to `*big.Int` in
`internal/mcp_impl/handlers.go::parseBalancesJson`. Stacked on **#142**
(the failing regression test); merging this flips the test green.

JSON numeric values reach the handler as `float64` (Go's default). The
previous code used `big.NewFloat(amount).Int(new(big.Int))`, which:

  - silently truncated fractional parts (`100.9` → `100`)
  - silently rounded values past `±(2^53 - 1)` (already lost in JSON
    decoding before reaching the handler)

The fix introduces a single guard before the conversion:

```go
if amount < -maxExactJSONInt || amount > maxExactJSONInt || amount != float64(int64(amount)) {
    return error
}
iBalances[account][asset] = big.NewInt(int64(amount))
```

where `maxExactJSONInt = 9_007_199_254_740_991` (`2^53 - 1`). The error
message names the offending `account/asset` so callers can pinpoint the
bad balance.

## Stack

| PR | What it does | Target |
| --- | --- | --- |
| [#142](https://github.com/formancehq/numscript/pull/142) | Failing regression tests | `main` |
| **this PR** | Adds the integer-validation guard | #142 branch |

## Test plan

- [x] `TestParseBalancesJsonRejectsNonIntegerAmounts` passes (red on #142, green here).
- [x] `TestParseBalancesJsonRejectsUnsafelyLargeAmounts` passes (red on #142, green here).
- [x] `TestParseBalancesJsonAcceptsExactIntegerAmounts` still passes.
- [x] All other tests stay green; `just pre-commit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
