### PR TITLE
fix: propagate specs file write errors in test init

### DIFF
--- a/internal/cmd/test_init.go
+++ b/internal/cmd/test_init.go
@@ -175,6 +175,10 @@ func makeSpecsFile(
 	return specs, nil
 }
 
+// jsonMarshalIndent is an indirection over json.MarshalIndent so that tests
+// can simulate marshaling failures.
+var jsonMarshalIndent = json.MarshalIndent
+
 func runTestInitCmd(opts testInitArgs) error {
 	// TODO check there isn't a specsfile already
 
@@ -189,7 +193,7 @@ func runTestInitCmd(opts testInitArgs) error {
 		return err
 	}
 
-	marshaled, err := json.MarshalIndent(specs, "", "  ")
+	marshaled, err := jsonMarshalIndent(specs, "", "  ")
 	if err != nil {
 		return fmt.Errorf("failed to marshal specs file: %w", err)
 	}

--- a/internal/cmd/test_init.go
+++ b/internal/cmd/test_init.go
@@ -189,9 +189,14 @@ func runTestInitCmd(opts testInitArgs) error {
 		return err
 	}
 
-	marshaled, _ := json.MarshalIndent(specs, "", "  ")
+	marshaled, err := json.MarshalIndent(specs, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to marshal specs file: %w", err)
+	}
 
-	_ = os.WriteFile(opts.path+".specs.json", marshaled, 0644)
+	if err := os.WriteFile(opts.path+".specs.json", marshaled, 0644); err != nil {
+		return fmt.Errorf("failed to write specs file: %w", err)
+	}
 
 	fmt.Printf("✅ Created specs file: %s.specs.json\n", opts.path)
 

--- a/internal/cmd/test_init_internal_test.go
+++ b/internal/cmd/test_init_internal_test.go
@@ -1,10 +1,13 @@
 package cmd
 
 import (
+	"encoding/json"
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
 
+	"github.com/formancehq/numscript/internal/specs_format"
 	"github.com/stretchr/testify/require"
 )
 
@@ -22,8 +25,49 @@ func TestRunTestInitCmdCreatesSpecsFile(t *testing.T) {
 	err := runTestInitCmd(testInitArgs{path: scriptPath})
 
 	require.NoError(t, err)
-	_, err = os.Stat(scriptPath + ".specs.json")
+
+	content, err := os.ReadFile(scriptPath + ".specs.json")
 	require.NoError(t, err)
+
+	var specs specs_format.Specs
+	require.NoError(t, json.Unmarshal(content, &specs))
+	require.Equal(t, "https://raw.githubusercontent.com/formancehq/numscript/main/specs.schema.json", specs.Schema)
+	require.Len(t, specs.TestCases, 1)
+	require.Equal(t, "example spec", specs.TestCases[0].It)
+}
+
+func TestRunTestInitCmdReturnsErrorWhenScriptMissing(t *testing.T) {
+	err := runTestInitCmd(testInitArgs{path: filepath.Join(t.TempDir(), "missing.num")})
+
+	require.Error(t, err)
+}
+
+func TestRunTestInitCmdReturnsErrorOnInvalidScript(t *testing.T) {
+	dir := t.TempDir()
+	scriptPath := filepath.Join(dir, "main.num")
+	require.NoError(t, os.WriteFile(scriptPath, []byte("send [USD/2 100] ("), 0644))
+
+	err := runTestInitCmd(testInitArgs{path: scriptPath})
+
+	require.Error(t, err)
+}
+
+func TestRunTestInitCmdReturnsMarshalError(t *testing.T) {
+	dir := t.TempDir()
+	scriptPath := filepath.Join(dir, "main.num")
+	require.NoError(t, os.WriteFile(scriptPath, []byte(testInitNumscript), 0644))
+
+	original := jsonMarshalIndent
+	jsonMarshalIndent = func(v any, prefix, indent string) ([]byte, error) {
+		return nil, errors.New("marshal failure")
+	}
+	t.Cleanup(func() { jsonMarshalIndent = original })
+
+	err := runTestInitCmd(testInitArgs{path: scriptPath})
+
+	require.Error(t, err)
+	require.ErrorContains(t, err, "failed to marshal specs file")
+	require.ErrorContains(t, err, "marshal failure")
 }
 
 func TestRunTestInitCmdReturnsWriteError(t *testing.T) {

--- a/internal/cmd/test_init_internal_test.go
+++ b/internal/cmd/test_init_internal_test.go
@@ -1,0 +1,42 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+const testInitNumscript = `send [USD/2 100] (
+	source = @world
+	destination = @bob
+)
+`
+
+func TestRunTestInitCmdCreatesSpecsFile(t *testing.T) {
+	dir := t.TempDir()
+	scriptPath := filepath.Join(dir, "main.num")
+	require.NoError(t, os.WriteFile(scriptPath, []byte(testInitNumscript), 0644))
+
+	err := runTestInitCmd(testInitArgs{path: scriptPath})
+
+	require.NoError(t, err)
+	_, err = os.Stat(scriptPath + ".specs.json")
+	require.NoError(t, err)
+}
+
+func TestRunTestInitCmdReturnsWriteError(t *testing.T) {
+	dir := t.TempDir()
+	scriptPath := filepath.Join(dir, "main.num")
+	require.NoError(t, os.WriteFile(scriptPath, []byte(testInitNumscript), 0644))
+
+	// Create a directory where the specs file should be written,
+	// so that os.WriteFile fails deterministically.
+	require.NoError(t, os.Mkdir(scriptPath+".specs.json", 0755))
+
+	err := runTestInitCmd(testInitArgs{path: scriptPath})
+
+	require.Error(t, err)
+	require.ErrorContains(t, err, "failed to write specs file")
+}


### PR DESCRIPTION
## Summary

Fixes [EN-1124](https://formance-team.atlassian.net/browse/EN-1124).

In `runTestInitCmd` (`internal/cmd/test_init.go`), the JSON marshal and `os.WriteFile` errors were silently ignored: on failure, the user still saw the "✅ Created specs file" success message and the command exited with code 0.

## Changes

- Propagate `json.MarshalIndent` and `os.WriteFile` errors, wrapped with context via `fmt.Errorf("...: %w", err)`.
- Only print the success message after a successful write.
- Add internal tests covering the success path and the write-failure path (deterministic failure by pre-creating a directory at the specs file path).

The diff is strictly limited to `runTestInitCmd` to avoid conflicts with the EN-1123 PR touching `makeSpecsFile`.

## Test plan

- `go test ./...` — all green
- `gofmt -l .` — no issues in changed files (`internal/parser/parser.go` is a pre-existing formatting issue on `main`, untouched here)

[EN-1124]: https://formance-team.atlassian.net/browse/EN-1124?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ