### PR TITLE
feat: add NUMSCRIPT_NO_TELEMETRY opt-out for crash reporting

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,3 +32,13 @@ curl -sSf https://raw.githubusercontent.com/formancehq/numscript/main/install.sh
 ```sh
 go install github.com/formancehq/numscript/cmd/numscript@latest
 ```
+
+### Telemetry
+
+Release builds of the `numscript` CLI send anonymous crash reports to [Sentry](https://sentry.io) when the program panics. A crash report contains the panic message, a stack trace, and the CLI version — nothing else. No reports are sent during normal operation, and development builds (built from source with `go install` or `go build`, where the version is `develop`) never send anything.
+
+To disable crash reporting entirely, set the `NUMSCRIPT_NO_TELEMETRY` environment variable to any non-empty value:
+
+```sh
+export NUMSCRIPT_NO_TELEMETRY=1
+```

--- a/cmd/numscript/main.go
+++ b/cmd/numscript/main.go
@@ -15,8 +15,16 @@ import (
 // -ldflags "-X main.Version=0.0.1"
 var Version string = "develop"
 
+// telemetryEnabled reports whether crash reporting should be active.
+// Telemetry is disabled in development builds (Version == "develop")
+// and when the NUMSCRIPT_NO_TELEMETRY environment variable is set to
+// any non-empty value.
+func telemetryEnabled() bool {
+	return Version != "develop" && os.Getenv("NUMSCRIPT_NO_TELEMETRY") == ""
+}
+
 func recoverPanic() {
-	if Version == "develop" {
+	if !telemetryEnabled() {
 		return
 	}
 
@@ -32,15 +40,18 @@ func recoverPanic() {
 }
 
 func main() {
-	if err := sentry.Init(sentry.ClientOptions{
-		Dsn:              "https://b8b6cfd5dab95e1258d80963c3db73bf@o4504394442539008.ingest.us.sentry.io/4507623538884608",
-		AttachStacktrace: true,
-	}); err != nil {
-		fmt.Fprintf(os.Stderr, "Failed to initialize Sentry: %v\n", err)
+	if telemetryEnabled() {
+		if err := sentry.Init(sentry.ClientOptions{
+			Dsn:              "https://b8b6cfd5dab95e1258d80963c3db73bf@o4504394442539008.ingest.us.sentry.io/4507623538884608",
+			AttachStacktrace: true,
+		}); err != nil {
+			fmt.Fprintf(os.Stderr, "Failed to initialize Sentry: %v\n", err)
+		}
+
+		defer sentry.Flush(2 * time.Second)
 	}
 
 	defer recoverPanic()
-	defer sentry.Flush(2 * time.Second)
 
 	cmd.Execute(cmd.CliOptions{
 		Version: Version,


### PR DESCRIPTION
## Summary

Fixes [EN-1129](https://formance-team.atlassian.net/browse/EN-1129).

Release binaries previously initialized Sentry unconditionally with a hardcoded DSN and sent crash reports (panic messages + stack traces) with no opt-out and no documentation.

This PR:

- Adds a `telemetryEnabled()` check in `cmd/numscript/main.go`: Sentry initialization and panic capture are skipped when the `NUMSCRIPT_NO_TELEMETRY` environment variable is set to any non-empty value.
- Preserves existing default behavior: telemetry stays on in release builds and off in development builds (`Version == "develop"`).
- Documents the behavior in a new "Telemetry" section in `README.md`, explaining what is sent (crash reports on panics in release builds only) and how to disable it.

## Test plan

- `go build ./...` passes
- `go test ./...` passes
- `gofmt -l .` clean for changed files (the only flagged file, `internal/parser/parser.go`, is pre-existing on `main` and untouched here)

[EN-1129]: https://formance-team.atlassian.net/browse/EN-1129?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ