### PR TITLE
chore: project hygiene fixes (badge, docs, gofmt, go version, workflow permissions)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,12 +12,16 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   PR:
     if: github.event_name == 'pull_request'
     name: Check PR Title
     runs-on: ubuntu-latest
     permissions:
+      pull-requests: read
       statuses: write
     steps:
       - uses: amannn/action-semantic-pull-request@v6

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,4 +3,4 @@
 You can update snaphshots with the
 `UPDATE_SNAPS=true` variable while running the tests
 
-If you need to update the grammar, you can generate the parser using the `generate-parser.sh` script (you'll need to install the antlr4 command first)
+If you need to update the grammar, you can generate the parser by running `just generate` (you'll need to install the antlr4 command first)

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![GitHub Release](https://img.shields.io/github/v/release/formancehq/numscript)](https://github.com/formancehq/numscript/releases)
 [![Go Reference](https://pkg.go.dev/badge/github.com/formancehq/numscript.svg)](https://pkg.go.dev/github.com/formancehq/numscript)
-[![Go](https://github.com/formancehq/numscript/actions/workflows/checks.yml/badge.svg)](https://github.com/formancehq/numscript/actions/workflows/checks.yml)
+[![Go](https://github.com/formancehq/numscript/actions/workflows/main.yml/badge.svg)](https://github.com/formancehq/numscript/actions/workflows/main.yml)
 [![codecov](https://codecov.io/gh/formancehq/numscript/graph/badge.svg?token=njjqGhFQ2p)](https://codecov.io/gh/formancehq/numscript)
 
 Numscript is the DSL used to express financial transaction within the [Formance](https://www.formance.com/) ledger.

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/formancehq/numscript
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/antlr4-go/antlr/v4 v4.13.1

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -570,7 +570,7 @@ func parseSaveStatement(saveCtx *antlrParser.SaveStatementContext) *SaveStatemen
 	return &SaveStatement{
 		Range:     ctxToRange(saveCtx),
 		SentValue: parseSentValue(saveCtx.SentValue()),
-		Account:    parseValueExpr(saveCtx.ValueExpr()),
+		Account:   parseValueExpr(saveCtx.ValueExpr()),
 	}
 }
 


### PR DESCRIPTION
Fixes [EN-1133](https://formance-team.atlassian.net/browse/EN-1133) — project hygiene batch.

## Changes

- **README.md** — CI badge pointed to `workflows/checks.yml`, which doesn't exist. Now points to `.github/workflows/main.yml` (both image and link URLs).
- **CONTRIBUTING.md** — referenced a nonexistent `generate-parser.sh` script. Updated to the actual command, `just generate` (still requires antlr4).
- **internal/parser/parser.go** — ran `gofmt -w`; it was the only non-generated file failing `gofmt -l` (one misaligned struct field).
- **go.mod** — bumped `go 1.25.0` → `go 1.26.0` to match the toolchain provided by `flake.nix` (`go_1_26`). Verified `go build ./...` and `go test ./...` pass.
- **.github/workflows/main.yml** — added a top-level `permissions: contents: read` block (minimal default for all jobs) and added `pull-requests: read` to the existing `PR` job permissions so `amannn/action-semantic-pull-request` can read the PR title (job-level permissions override the top-level block entirely, so `statuses: write` is kept there). Codecov uses its own token; GoReleaser/Earthly steps use `NUMARY_GITHUB_TOKEN` secrets, so `contents: read` is sufficient.

## Verification

- `go build ./...` — OK
- `go test ./...` — all packages pass
- `gofmt -l .` — clean (no unformatted files)

Note: mcp_impl test coverage is intentionally out of scope here (tracked with the float64 fix, EN-1117).

[EN-1133]: https://formance-team.atlassian.net/browse/EN-1133?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ