### PR TITLE
fix: return errors instead of os.Exit in specs_format

### DIFF
--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -570,7 +570,7 @@ func parseSaveStatement(saveCtx *antlrParser.SaveStatementContext) *SaveStatemen
 	return &SaveStatement{
 		Range:     ctxToRange(saveCtx),
 		SentValue: parseSentValue(saveCtx.SentValue()),
-		Account:    parseValueExpr(saveCtx.ValueExpr()),
+		Account:   parseValueExpr(saveCtx.ValueExpr()),
 	}
 }
 

--- a/internal/specs_format/runner.go
+++ b/internal/specs_format/runner.go
@@ -59,8 +59,7 @@ func ReadSpecsFiles(paths []string) ([]RawSpec, error) {
 
 		info, err := os.Stat(root)
 		if err != nil {
-			_, _ = os.Stderr.Write([]byte(err.Error()))
-			os.Exit(1)
+			return nil, err
 		}
 
 		if !info.IsDir() {

--- a/internal/specs_format/runner_test.go
+++ b/internal/specs_format/runner_test.go
@@ -2,6 +2,7 @@ package specs_format_test
 
 import (
 	"bytes"
+	"os"
 	"testing"
 
 	"github.com/formancehq/numscript/internal/specs_format"
@@ -23,6 +24,13 @@ func TestShowDiff(t *testing.T) {
 		},
 	)
 	snaps.MatchSnapshot(t, buf.String())
+}
+
+func TestReadSpecsFilesNonexistentPath(t *testing.T) {
+	specs, err := specs_format.ReadSpecsFiles([]string{"path/that/does/not/exist"})
+	require.Error(t, err)
+	require.ErrorIs(t, err, os.ErrNotExist)
+	require.Nil(t, specs)
 }
 
 func TestSingleTest(t *testing.T) {


### PR DESCRIPTION
## Summary

Fixes [EN-1125](https://formance-team.atlassian.net/browse/EN-1125).

`specs_format.ReadSpecsFiles` called `os.Exit(1)` (after writing to stderr) when `os.Stat` failed on a given path. Library code must not terminate the process: it bypasses the caller's error handling and makes the function untestable.

## Changes

- `internal/specs_format/runner.go`: `ReadSpecsFiles` now returns the `os.Stat` error instead of writing to stderr and calling `os.Exit(1)`. The function signature already returned `([]RawSpec, error)`, so no signature change was needed.
- Audited the rest of the `internal/specs_format` package: this was the only `os.Exit` call. The `filepath.WalkDir` callback already propagates errors correctly.
- `internal/cmd/test.go` (the only caller) already prints the error to stderr and exits with code 1, so the CLI behavior is unchanged.
- Added `TestReadSpecsFilesNonexistentPath` verifying that a nonexistent path returns an error (wrapping `os.ErrNotExist`) without killing the test process.
- Drive-by: applied `gofmt` to `internal/parser/parser.go` (pre-existing formatting drift on `main`) so `gofmt -l .` is clean.

## Testing

- `go test ./...` — all packages pass
- `gofmt -l .` — no output

[EN-1125]: https://formance-team.atlassian.net/browse/EN-1125?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ