### PR TITLE
fix: sort check diagnostics in source order with a valid comparator

### DIFF
--- a/internal/cmd/check.go
+++ b/internal/cmd/check.go
@@ -10,6 +10,15 @@ import (
 	"github.com/spf13/cobra"
 )
 
+// sortDiagnostics sorts diagnostics in source order (by start position,
+// line first and then character), using a strict less function as required
+// by the sort.Slice contract.
+func sortDiagnostics(diagnostics []analysis.Diagnostic) {
+	sort.Slice(diagnostics, func(i, j int) bool {
+		return diagnostics[i].Range.Start.Lt(diagnostics[j].Range.Start)
+	})
+}
+
 func check(path string) {
 	dat, err := os.ReadFile(path)
 	if err != nil {
@@ -18,12 +27,7 @@ func check(path string) {
 	}
 
 	res := analysis.CheckSource(string(dat))
-	sort.Slice(res.Diagnostics, func(i, j int) bool {
-		p1 := res.Diagnostics[i].Range.Start
-		p2 := res.Diagnostics[j].Range.Start
-
-		return p2.GtEq(p1)
-	})
+	sortDiagnostics(res.Diagnostics)
 
 	for i, d := range res.Diagnostics {
 		if i != 0 {

--- a/internal/cmd/check_test.go
+++ b/internal/cmd/check_test.go
@@ -1,0 +1,57 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/formancehq/numscript/internal/analysis"
+	"github.com/formancehq/numscript/internal/parser"
+	"github.com/stretchr/testify/require"
+)
+
+func diagnosticAt(line int, character int) analysis.Diagnostic {
+	return analysis.Diagnostic{
+		Range: parser.Range{
+			Start: parser.Position{Line: line, Character: character},
+		},
+	}
+}
+
+func TestSortDiagnosticsInSourceOrder(t *testing.T) {
+	t.Parallel()
+
+	diagnostics := []analysis.Diagnostic{
+		diagnosticAt(3, 0),
+		diagnosticAt(1, 10),
+		diagnosticAt(1, 2),
+		diagnosticAt(0, 5),
+	}
+
+	sortDiagnostics(diagnostics)
+
+	require.Equal(t, []analysis.Diagnostic{
+		diagnosticAt(0, 5),
+		diagnosticAt(1, 2),
+		diagnosticAt(1, 10),
+		diagnosticAt(3, 0),
+	}, diagnostics)
+}
+
+func TestSortDiagnosticsWithEqualPositions(t *testing.T) {
+	t.Parallel()
+
+	// Equal positions must not panic or misbehave: the comparator has to be
+	// strict (a valid less function), unlike the previous GtEq-based one.
+	diagnostics := []analysis.Diagnostic{
+		diagnosticAt(2, 4),
+		diagnosticAt(2, 4),
+		diagnosticAt(0, 0),
+	}
+
+	sortDiagnostics(diagnostics)
+
+	require.Equal(t, []analysis.Diagnostic{
+		diagnosticAt(0, 0),
+		diagnosticAt(2, 4),
+		diagnosticAt(2, 4),
+	}, diagnostics)
+}

--- a/internal/parser/range.go
+++ b/internal/parser/range.go
@@ -29,6 +29,17 @@ func (p1 *Position) GtEq(p2 Position) bool {
 	return p1.Line > p2.Line
 }
 
+// Lt reports whether p1 comes strictly before p2 in source order,
+// comparing by line first and then by character.
+// It is a strict ordering, suitable as a less function for sorting.
+func (p1 Position) Lt(p2 Position) bool {
+	if p1.Line == p2.Line {
+		return p1.Character < p2.Character
+	}
+
+	return p1.Line < p2.Line
+}
+
 func (p *Position) AsRange() Range {
 	//  position >= r.Start && r.End >= position
 	return Range{Start: *p, End: *p}

--- a/internal/parser/range_test.go
+++ b/internal/parser/range_test.go
@@ -53,6 +53,50 @@ func TestPositionGt(t *testing.T) {
 
 }
 
+func TestPositionLt(t *testing.T) {
+	t.Parallel()
+
+	assert.False(t, parser.Position{
+		Line:      10,
+		Character: 20,
+	}.Lt(parser.Position{
+		Line:      10,
+		Character: 20,
+	}), "a position is not Lt itself (strict ordering)")
+
+	assert.True(t, parser.Position{
+		Line:      10,
+		Character: 20,
+	}.Lt(parser.Position{
+		Line:      100,
+		Character: 0,
+	}), "x is Lt y when x line is lower")
+
+	assert.False(t, parser.Position{
+		Line:      100,
+		Character: 0,
+	}.Lt(parser.Position{
+		Line:      10,
+		Character: 20,
+	}), "x is not Lt y when x line is greater")
+
+	assert.True(t, parser.Position{
+		Line:      0,
+		Character: 19,
+	}.Lt(parser.Position{
+		Line:      0,
+		Character: 20,
+	}), "x is Lt y when they are on the same line and the char is lower")
+
+	assert.False(t, parser.Position{
+		Line:      0,
+		Character: 20,
+	}.Lt(parser.Position{
+		Line:      0,
+		Character: 19,
+	}), "x is not Lt y when they are on the same line and the char is greater")
+}
+
 func TestContainsSameLine(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

Fixes [EN-1120](https://formance-team.atlassian.net/browse/EN-1120).

The `numscript check` command sorted diagnostics with `sort.Slice` using `p2.GtEq(p1)` as the less function. This had two problems:

1. **Invalid comparator**: `Position.GtEq` is non-strict, so two diagnostics at the same position compare "less" both ways, violating the `sort.Slice` contract (undefined behavior).
2. **Reverse order**: the comparison sorted diagnostics descending, so they were printed in reverse source order.

## Changes

- Added a strict `Position.Lt` method in `internal/parser/range.go` (compares by line, then character), with unit tests.
- Extracted the sort in `internal/cmd/check.go` into a testable `sortDiagnostics` helper that sorts ascending using `Lt`.
- Added tests covering source-order sorting and equal-position safety.

## Testing

- `go test ./...` passes.
- `gofmt -l` clean on all touched files (the one flagged file, `internal/parser/parser.go`, is pre-existing on `main` and untouched here).
- Manual check on a file with two undeclared variables now prints diagnostics in ascending source order.

[EN-1120]: https://formance-team.atlassian.net/browse/EN-1120?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ