### PR TITLE
fix: don't panic on incomplete var declaration with origin

### DIFF
--- a/internal/analysis/check.go
+++ b/internal/analysis/check.go
@@ -250,7 +250,7 @@ func (res *CheckResult) check() {
 				res.checkDuplicateVars(*varDecl.Name, varDecl)
 			}
 
-			if varDecl.Origin != nil {
+			if varDecl.Origin != nil && *varDecl.Origin != nil && varDecl.Type != nil {
 				res.checkExpression(*varDecl.Origin, varDecl.Type.Name)
 				res.unifyNodeWith(*varDecl.Origin, res.GetVarDeclType(varDecl))
 			}

--- a/internal/analysis/check_test.go
+++ b/internal/analysis/check_test.go
@@ -1193,3 +1193,26 @@ send [USD/2 100000] (
 	)
 
 }
+
+func TestIncompleteVarOriginDoesNotPanic(t *testing.T) {
+	t.Parallel()
+
+	// regression test for EN-1116: these incomplete var declarations
+	// used to make CheckSource panic with a nil pointer dereference
+	inputs := []string{
+		`vars { number $n = `,
+		`vars { number $n = }`,
+		`vars { $x = }`,
+		`vars { $x = `,
+		`vars { number $n = ` + "\n" + `}`,
+	}
+
+	for _, input := range inputs {
+		t.Run(input, func(t *testing.T) {
+			t.Parallel()
+
+			diagnostics := checkSource(input)
+			require.NotEmpty(t, diagnostics)
+		})
+	}
+}

--- a/internal/parser/__snapshots__/parser_fault_tolerance_test.snap
+++ b/internal/parser/__snapshots__/parser_fault_tolerance_test.snap
@@ -383,7 +383,7 @@ parser.Program{
                     },
                     Name: "asset",
                 },
-                Origin: &nil,
+                Origin: (*parser.ValueExpr)(nil),
             },
         },
     },

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -139,7 +139,11 @@ func parseVarDeclaration(varDecl antlrParser.IVarDeclarationContext) *VarDeclara
 	var origin *ValueExpr
 	if varDecl.VarOrigin() != nil {
 		expr := parseValueExpr(varDecl.VarOrigin().ValueExpr())
-		origin = &expr
+		// when the origin expression is missing or malformed,
+		// parseValueExpr returns nil; do not wrap it in a non-nil pointer
+		if expr != nil {
+			origin = &expr
+		}
 	}
 
 	return &VarDeclaration{
@@ -570,7 +574,7 @@ func parseSaveStatement(saveCtx *antlrParser.SaveStatementContext) *SaveStatemen
 	return &SaveStatement{
 		Range:     ctxToRange(saveCtx),
 		SentValue: parseSentValue(saveCtx.SentValue()),
-		Account:    parseValueExpr(saveCtx.ValueExpr()),
+		Account:   parseValueExpr(saveCtx.ValueExpr()),
 	}
 }
 


### PR DESCRIPTION
## Bug

`analysis.CheckSource` panics with a nil pointer dereference when checking a source containing an incomplete var declaration with an origin (`= ...`). Since there is no `recover` anywhere, this crashes the LSP server and `numscript check`.

Two nil derefs in `internal/analysis/check.go` (inside the `if varDecl.Origin != nil` branch of `check()`):

1. `*varDecl.Origin` can be a **nil `ValueExpr` interface**: when the origin expression is missing or malformed, `parseValueExpr` returns `nil`, but `parseVarDeclaration` still wrapped it in a non-nil `*ValueExpr` pointer. Calling `(*varDecl.Origin).GetRange()` in `unifyNodeWith` then panics.
2. `varDecl.Type` can be **nil** (e.g. `vars { $x = }`): nil guards exist elsewhere (lines 245 and 308) but `varDecl.Type.Name` was dereferenced unguarded.

## Reproduction

```go
analysis.CheckSource("vars { number $n = ")  // panic: nil pointer dereference
analysis.CheckSource("vars { number $n = }") // panic: nil pointer dereference
```

## Fix

- **Parser** (`internal/parser/parser.go`, `parseVarDeclaration`): don't produce a non-nil `Origin` pointer to a nil `ValueExpr` interface — leave `Origin` nil when the origin expression can't be parsed.
- **Analysis** (`internal/analysis/check.go`): defensively guard the origin check with `*varDecl.Origin != nil && varDecl.Type != nil`.
- Updated the `TestFaultToleranceIncompleteOrigin` snapshot, which had captured the buggy `Origin: &nil` value.
- Added regression tests in `internal/analysis/check_test.go` covering both repro inputs plus similar malformed variants, asserting `CheckSource` returns diagnostics without panicking.

`go test ./...` passes and `gofmt -l .` reports no unformatted files.

## References

Jira: [EN-1116](https://formance-team.atlassian.net/browse/EN-1116)

[EN-1116]: https://formance-team.atlassian.net/browse/EN-1116?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ