### PR TITLE
fix: deep-copy balances returned by Store instead of mutating caller state

### DIFF
--- a/internal/interpreter/balances.go
+++ b/internal/interpreter/balances.go
@@ -69,6 +69,10 @@ func (b Balances) filterQuery(q BalanceQuery) BalanceQuery {
 }
 
 // Merge balances by adding balances in the "update" arg
+//
+// Values are deep-copied, so that the merged Balances never aliases the
+// *big.Int values owned by the "update" arg (which may belong to a
+// third-party Store implementation and must not be mutated in place)
 func (b Balances) Merge(update Balances) {
 	// merge queried balance
 	for acc, accBalances := range update {
@@ -77,7 +81,7 @@ func (b Balances) Merge(update Balances) {
 		})
 
 		for curr, amt := range accBalances {
-			cachedAcc[curr] = amt
+			cachedAcc[curr] = new(big.Int).Set(amt)
 		}
 	}
 }

--- a/internal/interpreter/balances_test.go
+++ b/internal/interpreter/balances_test.go
@@ -1,9 +1,11 @@
 package interpreter
 
 import (
+	"context"
 	"math/big"
 	"testing"
 
+	"github.com/formancehq/numscript/internal/parser"
 	"github.com/gkampitakis/go-snaps/snaps"
 	"github.com/stretchr/testify/require"
 )
@@ -47,6 +49,62 @@ func TestCloneBalances(t *testing.T) {
 	fullBalance["alice"]["USD/2"].Set(big.NewInt(42))
 
 	require.Equal(t, big.NewInt(2), cloned["alice"]["USD/2"])
+}
+
+// a Store implementation which returns pointers to its internal state,
+// so that we can detect whether the interpreter mutates them
+type aliasingStore struct {
+	balances Balances
+}
+
+func (s *aliasingStore) GetBalances(_ context.Context, q BalanceQuery) (Balances, error) {
+	out := Balances{}
+	for account, currencies := range q {
+		accountBalance := AccountBalance{}
+		out[account] = accountBalance
+		for _, curr := range currencies {
+			// note: this aliases the store's internal *big.Int
+			accountBalance[curr] = s.balances[account][curr]
+		}
+	}
+	return out, nil
+}
+
+func (s *aliasingStore) GetAccountsMetadata(_ context.Context, _ MetadataQuery) (AccountsMetadata, error) {
+	return AccountsMetadata{}, nil
+}
+
+func TestRunProgramDoesNotMutateStoreBalances(t *testing.T) {
+	t.Parallel()
+
+	aliceBalance := big.NewInt(100)
+	store := &aliasingStore{
+		balances: Balances{
+			"alice": AccountBalance{
+				"USD/2": aliceBalance,
+			},
+		},
+	}
+
+	parseResult := parser.Parse(`send [USD/2 100] (
+	source = @alice
+	destination = @bob
+)`)
+	require.Empty(t, parseResult.Errors)
+
+	result, err := RunProgram(context.Background(), parseResult.Value, nil, store, nil)
+	require.Nil(t, err)
+	require.Equal(t, []Posting{
+		{
+			Source:      "alice",
+			Destination: "bob",
+			Amount:      big.NewInt(100),
+			Asset:       "USD/2",
+		},
+	}, result.Postings)
+
+	// the store's internal state must not have been mutated by the run
+	require.Equal(t, big.NewInt(100), aliceBalance)
 }
 
 func TestPrettyPrintBalance(t *testing.T) {

--- a/internal/interpreter/interpreter.go
+++ b/internal/interpreter/interpreter.go
@@ -28,6 +28,13 @@ type Balances map[string]AccountBalance
 type AccountMetadata = map[string]string
 type AccountsMetadata map[string]AccountMetadata
 
+// Store is the interface implemented by clients to provide the data
+// (balances, accounts metadata) needed to run a program.
+//
+// Ownership of the returned values is transferred to the caller once the
+// methods return: the interpreter deep-copies the returned balances before
+// using them, so implementations are free to return pointers to their
+// internal state without risking it being mutated during the run.
 type Store interface {
 	GetBalances(context.Context, BalanceQuery) (Balances, error)
 	GetAccountsMetadata(context.Context, MetadataQuery) (AccountsMetadata, error)


### PR DESCRIPTION
## Summary

Fixes [EN-1118](https://formance-team.atlassian.net/browse/EN-1118).

`Balances.Merge` stored the `*big.Int` pointers returned by `Store.GetBalances` directly into the interpreter's balance cache. The interpreter then mutates cached balances in place (`pushSender`, `pushReceiver`, and the `save` statement), so any third-party `Store` implementation returning pointers to its internal state had that state silently corrupted by `RunProgram`. The built-in stores happen to copy defensively, which is why the bug only affects external implementations.

## Changes

- `Balances.Merge` now deep-copies each amount (`new(big.Int).Set(amt)`) instead of aliasing the pointers returned by the `Store`.
- Added a doc comment on the `Store` interface clarifying that ownership of returned values transfers to the caller, and that implementations may safely return pointers to internal state.
- Added a regression test (`TestRunProgramDoesNotMutateStoreBalances`) using a `Store` stub that returns aliased `*big.Int`s; it verifies the stub's internal state is unchanged after a `send`. The test fails on `main` (balance drained from 100 to 0) and passes with this fix.

## Testing

- `go test ./...` passes.
- `gofmt -l .` only flags `internal/parser/parser.go`, which is pre-existing on `main` and untouched here.

[EN-1118]: https://formance-team.atlassian.net/browse/EN-1118?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ