### PR TITLE
fix: test init feature-flag retry used zero default balance

### DIFF
--- a/internal/cmd/test_init.go
+++ b/internal/cmd/test_init.go
@@ -104,15 +104,24 @@ func MakeSpecsFile(source string) (specs_format.Specs, error) {
 		vars,
 		map[string]struct{}{},
 		big.NewInt(100),
+		maxSpecsRetries,
 	)
 }
+
+// maxSpecsRetries bounds the number of times makeSpecsFile may retry
+// after recoverable interpreter errors (missing funds, missing feature flags).
+const maxSpecsRetries = 16
 
 func makeSpecsFile(
 	program parser.Program,
 	vars map[string]string,
 	featureFlags map[string]struct{},
 	defaultBalance *big.Int,
+	retriesLeft int,
 ) (specs_format.Specs, error) {
+	if retriesLeft < 0 {
+		return specs_format.Specs{}, fmt.Errorf("could not generate the specs file: exceeded the maximum number of retries (%d)", maxSpecsRetries)
+	}
 
 	store := TestInitStore{
 		DefaultBalance: defaultBalance,
@@ -137,6 +146,7 @@ func makeSpecsFile(
 				vars,
 				featureFlags,
 				&missingFundsErr.Needed,
+				retriesLeft-1,
 			)
 		}
 
@@ -147,7 +157,8 @@ func makeSpecsFile(
 				program,
 				vars,
 				featureFlags,
-				&missingFundsErr.Needed,
+				defaultBalance,
+				retriesLeft-1,
 			)
 		}
 

--- a/internal/cmd/test_init_internal_test.go
+++ b/internal/cmd/test_init_internal_test.go
@@ -1,0 +1,32 @@
+package cmd
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/formancehq/numscript/internal/parser"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMakeSpecsFileRetryExhaustion(t *testing.T) {
+	parseResult := parser.Parse(`
+		send [USD/2 100] (
+			 source = @alice
+			 destination = @bob
+		)
+ `)
+	require.Empty(t, parseResult.Errors)
+
+	// With a zero default balance the program keeps failing with
+	// MissingFundsErr; a zero retry budget must surface a clear error
+	// instead of recursing.
+	_, err := makeSpecsFile(
+		parseResult.Value,
+		map[string]string{},
+		map[string]struct{}{},
+		big.NewInt(0),
+		0,
+	)
+
+	require.ErrorContains(t, err, "exceeded the maximum number of retries")
+}

--- a/internal/cmd/test_init_test.go
+++ b/internal/cmd/test_init_test.go
@@ -45,3 +45,23 @@ func TestMakeSpecsFileRetryForMissingFeatureFlags(t *testing.T) {
 	require.Nil(t, err)
 	require.Equal(t, []string{"experimental-oneof"}, out.FeatureFlags)
 }
+
+func TestMakeSpecsFileFeatureFlagRetryKeepsDefaultBalance(t *testing.T) {
+	// The amount is lower than the default balance (100), so the
+	// feature-flag retry must keep using the default balance instead
+	// of falling back to a zero balance.
+	out, err := cmd.MakeSpecsFile(`
+		send [USD/2 42] (
+			 source = oneof { @alice }
+			 destination = @bob
+		)
+ `)
+
+	require.Nil(t, err)
+	require.Equal(t, []string{"experimental-oneof"}, out.FeatureFlags)
+	require.Equal(t, interpreter.Balances{
+		"alice": interpreter.AccountBalance{
+			"USD/2": big.NewInt(100),
+		},
+	}, out.Balances)
+}


### PR DESCRIPTION
## Summary

Fixes [EN-1123](https://formance-team.atlassian.net/browse/EN-1123).

In `makeSpecsFile` (`internal/cmd/test_init.go`), the missing-feature-flag retry branch passed `&missingFundsErr.Needed` to the recursive call. In that branch the `MissingFundsErr` type assertion had **failed**, so `missingFundsErr` was the zero value and the retry ran with a default balance of `0` instead of the current default (`100`). This caused generated specs to use wrong balances (e.g. the send amount instead of the intended default) whenever a script required a feature flag.

## Changes

- The feature-flag retry now passes the current `defaultBalance` parameter through instead of the zero-valued `&missingFundsErr.Needed`.
- `makeSpecsFile` recursion is now bounded by a `retriesLeft` counter (`maxSpecsRetries = 16`); exceeding it returns a clear error instead of recursing indefinitely.

## Tests

- Added `TestMakeSpecsFileFeatureFlagRetryKeepsDefaultBalance`: a script using `oneof` (which requires the `experimental-oneof` flag) with a send amount below the default balance now asserts the generated specs keep the `100` default balance. Verified the test fails (balance `42`) against the pre-fix code.
- `go test ./...` green, `gofmt -l` clean on changed files (`internal/parser/parser.go` is pre-existing on main).

[EN-1123]: https://formance-team.atlassian.net/browse/EN-1123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ