### PR TITLE
fix: parse MCP balance amounts exactly instead of via float64

### DIFF
--- a/internal/mcp_impl/handlers.go
+++ b/internal/mcp_impl/handlers.go
@@ -2,8 +2,11 @@ package mcp_impl
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"math"
 	"math/big"
+	"strconv"
 	"strings"
 
 	"github.com/formancehq/numscript/internal/analysis"
@@ -12,6 +15,48 @@ import (
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
 )
+
+// maxSafeAmountFloat is 2^53. Integers whose absolute value is strictly below
+// this bound are exactly representable as float64, so a JSON number that
+// decodes to such a float64 is guaranteed to carry the caller's exact value.
+const maxSafeAmountFloat = float64(1 << 53)
+
+// parseAmount converts a JSON-decoded balance amount into a big.Int without
+// any precision loss.
+//
+// Amounts can be sent either as JSON numbers or as strings. JSON numbers are
+// decoded to float64 by the MCP transport, so they are only accepted when
+// they are exact integers within the float64 safe-integer range (|n| < 2^53);
+// anything else must be sent as a string to preserve precision.
+func parseAmount(amountRaw any) (*big.Int, error) {
+	switch amount := amountRaw.(type) {
+	case string:
+		n, ok := new(big.Int).SetString(strings.TrimSpace(amount), 10)
+		if !ok {
+			return nil, fmt.Errorf("expected an integer string as amount, got: %q", amount)
+		}
+		return n, nil
+
+	case json.Number:
+		n, ok := new(big.Int).SetString(amount.String(), 10)
+		if !ok {
+			return nil, fmt.Errorf("expected an integer amount, got: %v", amount)
+		}
+		return n, nil
+
+	case float64:
+		if amount != math.Trunc(amount) {
+			return nil, fmt.Errorf("expected an integer amount, got a non-integer number: %v", amount)
+		}
+		if math.Abs(amount) >= maxSafeAmountFloat {
+			return nil, fmt.Errorf("amount %v is outside the range JSON numbers can represent exactly; pass the amount as a string instead, e.g. \"9007199254740993\"", strconv.FormatFloat(amount, 'f', -1, 64))
+		}
+		return big.NewInt(int64(amount)), nil
+
+	default:
+		return nil, fmt.Errorf("expected a number or an integer string as amount, got: %v", amountRaw)
+	}
+}
 
 func parseBalancesJson(balancesRaw any) (interpreter.Balances, *mcp.CallToolResult) {
 	balances, ok := balancesRaw.(map[string]any)
@@ -31,12 +76,10 @@ func parseBalancesJson(balancesRaw any) (interpreter.Balances, *mcp.CallToolResu
 		}
 
 		for asset, amountRaw := range assets {
-			amount, ok := amountRaw.(float64)
-			if !ok {
-				return interpreter.Balances{}, mcp.NewToolResultError(fmt.Sprintf("Expected float for amount: %v", amountRaw))
+			n, err := parseAmount(amountRaw)
+			if err != nil {
+				return interpreter.Balances{}, mcp.NewToolResultError(fmt.Sprintf("Invalid amount for account %q, asset %q: %v", account, asset, err))
 			}
-
-			n, _ := big.NewFloat(amount).Int(new(big.Int))
 			iBalances[account][asset] = n
 		}
 	}
@@ -77,6 +120,7 @@ func addEvalTool(s *server.MCPServer) {
 			mcp.Required(),
 			mcp.Description(`The accounts' balances. A nested map from the account name, to the asset, to its integer amount.
 			For example: { "alice": { "USD/2": 100, "EUR/2": -42 }, "bob": { "BTC": 1 } }
+			Amounts whose absolute value is 2^53 or greater must be passed as decimal strings to avoid precision loss, e.g. { "alice": { "USD/2": "9007199254740993" } }
 			`),
 		),
 		mcp.WithObject("vars",

--- a/internal/mcp_impl/handlers_test.go
+++ b/internal/mcp_impl/handlers_test.go
@@ -2,6 +2,8 @@ package mcp_impl
 
 import (
 	"context"
+	"encoding/json"
+	"math/big"
 	"testing"
 
 	"github.com/mark3labs/mcp-go/mcp"
@@ -25,4 +27,160 @@ func TestHandleEvalToolRejectsParseErrors(t *testing.T) {
 	text, ok := result.Content[0].(mcp.TextContent)
 	require.True(t, ok)
 	require.Contains(t, text.Text, "mismatched input")
+}
+
+// errorText extracts the text of an error tool result.
+func errorText(t *testing.T, result *mcp.CallToolResult) string {
+	t.Helper()
+	require.NotNil(t, result)
+	require.True(t, result.IsError)
+	require.NotEmpty(t, result.Content)
+	text, ok := result.Content[0].(mcp.TextContent)
+	require.True(t, ok)
+	return text.Text
+}
+
+func TestParseAmountExactSmallInteger(t *testing.T) {
+	n, err := parseAmount(float64(100))
+	require.NoError(t, err)
+	require.Equal(t, big.NewInt(100), n)
+}
+
+func TestParseAmountNegativeInteger(t *testing.T) {
+	n, err := parseAmount(float64(-42))
+	require.NoError(t, err)
+	require.Equal(t, big.NewInt(-42), n)
+}
+
+func TestParseAmountLargeIntegerAsString(t *testing.T) {
+	// 2^53 + 1 cannot be represented exactly as a float64,
+	// but must round-trip exactly when sent as a string
+	n, err := parseAmount("9007199254740993")
+	require.NoError(t, err)
+
+	expected, ok := new(big.Int).SetString("9007199254740993", 10)
+	require.True(t, ok)
+	require.Equal(t, expected, n)
+}
+
+func TestParseAmountNegativeLargeIntegerAsString(t *testing.T) {
+	n, err := parseAmount("-9007199254740993")
+	require.NoError(t, err)
+
+	expected, ok := new(big.Int).SetString("-9007199254740993", 10)
+	require.True(t, ok)
+	require.Equal(t, expected, n)
+}
+
+func TestParseAmountJsonNumber(t *testing.T) {
+	n, err := parseAmount(json.Number("9007199254740993"))
+	require.NoError(t, err)
+
+	expected, ok := new(big.Int).SetString("9007199254740993", 10)
+	require.True(t, ok)
+	require.Equal(t, expected, n)
+}
+
+func TestParseAmountRejectsUnsafeFloat(t *testing.T) {
+	// 2^53 + 1 sent as a JSON number arrives as float64(9007199254740992):
+	// the precision loss is undetectable, so the amount must be rejected
+	// instead of being silently rounded
+	_, err := parseAmount(float64(9007199254740993))
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "pass the amount as a string")
+}
+
+func TestParseAmountRejectsFractional(t *testing.T) {
+	_, err := parseAmount(float64(100.5))
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "non-integer")
+}
+
+func TestParseAmountRejectsNonNumericString(t *testing.T) {
+	_, err := parseAmount("100.5")
+	require.Error(t, err)
+
+	_, err = parseAmount("not a number")
+	require.Error(t, err)
+}
+
+func TestParseAmountRejectsInvalidType(t *testing.T) {
+	_, err := parseAmount(true)
+	require.Error(t, err)
+
+	_, err = parseAmount(nil)
+	require.Error(t, err)
+}
+
+func TestParseBalancesJsonExactAmounts(t *testing.T) {
+	// simulate the MCP transport: arguments arrive as the result of
+	// json.Unmarshal into map[string]any (numbers become float64)
+	var balancesRaw any
+	require.NoError(t, json.Unmarshal(
+		[]byte(`{ "alice": { "USD/2": 100, "EUR/2": -42 }, "bob": { "BTC": "9007199254740993" } }`),
+		&balancesRaw,
+	))
+
+	balances, mcpErr := parseBalancesJson(balancesRaw)
+	require.Nil(t, mcpErr)
+
+	require.Equal(t, big.NewInt(100), balances["alice"]["USD/2"])
+	require.Equal(t, big.NewInt(-42), balances["alice"]["EUR/2"])
+
+	expected, ok := new(big.Int).SetString("9007199254740993", 10)
+	require.True(t, ok)
+	require.Equal(t, expected, balances["bob"]["BTC"])
+}
+
+func TestParseBalancesJsonRejectsUnsafeFloat(t *testing.T) {
+	var balancesRaw any
+	require.NoError(t, json.Unmarshal(
+		[]byte(`{ "alice": { "USD/2": 9007199254740993 } }`),
+		&balancesRaw,
+	))
+
+	_, mcpErr := parseBalancesJson(balancesRaw)
+	text := errorText(t, mcpErr)
+	require.Contains(t, text, `account "alice"`)
+	require.Contains(t, text, `asset "USD/2"`)
+	require.Contains(t, text, "pass the amount as a string")
+}
+
+func TestParseBalancesJsonRejectsFractional(t *testing.T) {
+	var balancesRaw any
+	require.NoError(t, json.Unmarshal(
+		[]byte(`{ "alice": { "USD/2": 100.5 } }`),
+		&balancesRaw,
+	))
+
+	_, mcpErr := parseBalancesJson(balancesRaw)
+	require.Contains(t, errorText(t, mcpErr), "non-integer")
+}
+
+func TestHandleEvalToolUsesExactBalances(t *testing.T) {
+	// end-to-end: a balance above 2^53 passed as a string is used exactly
+	result, err := handleEvalTool(context.Background(), mcp.CallToolRequest{
+		Params: mcp.CallToolParams{
+			Arguments: map[string]any{
+				"script": `send [COIN 9007199254740993] (
+	source = @alice
+	destination = @bob
+)`,
+				"balances": map[string]any{
+					"alice": map[string]any{
+						"COIN": "9007199254740993",
+					},
+				},
+				"vars": map[string]any{},
+			},
+		},
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.False(t, result.IsError)
+	require.NotEmpty(t, result.Content)
+	text, ok := result.Content[0].(mcp.TextContent)
+	require.True(t, ok)
+	require.Contains(t, text.Text, "9007199254740993")
 }


### PR DESCRIPTION
## Bug

Fixes [EN-1117](https://formance-team.atlassian.net/browse/EN-1117).

`parseBalancesJson` in `internal/mcp_impl/handlers.go` decoded balance amounts as `float64` and converted them via `big.NewFloat(amount).Int(...)`. This silently corrupted amounts:

- Integers at or above 2^53 were silently rounded (e.g. `9007199254740993` became `9007199254740992`).
- Fractional inputs like `100.5` were silently truncated to `100`.

For a monetary tool built on `big.Int`, silent precision loss is unacceptable.

## Fix

mcp-go (v0.45.0) unmarshals tool-call arguments with the standard `encoding/json` decoder into `map[string]any`, so JSON numbers always arrive as `float64` — the raw JSON is not recoverable at that point. The new `parseAmount` helper therefore:

- **Accepts string amounts** (and `json.Number`), parsed exactly into `big.Int` via `SetString` — this is the lossless path for arbitrarily large amounts.
- **Keeps backward compatibility for ordinary integer JSON numbers**: a `float64` is accepted only if it is an exact integer with `|n| < 2^53` (the float64 safe-integer range, where the decoded value is guaranteed to match the caller's literal).
- **Rejects everything else with a clear error** instead of truncating/rounding:
  - non-integer numbers (e.g. `100.5`)
  - integers at or above 2^53 sent as JSON numbers, with a message telling the caller to pass the amount as a string

The `balances` tool parameter description now documents the string form for large amounts.

## Tests

Added in `internal/mcp_impl/handlers_test.go`:

- exact small integers and negative amounts parse correctly
- `2^53 + 1` as a JSON string parses exactly
- `2^53 + 1` as a JSON number is rejected (not silently rounded), with the error suggesting the string form
- fractional amounts (`100.5`) are rejected
- non-numeric strings and invalid types are rejected
- `parseBalancesJson` round-trips a real JSON payload (mixed number/string amounts) exactly, and errors include account/asset context
- end-to-end `handleEvalTool` run moving `9007199254740993` units using a string balance

`go test ./...` and `gofmt -l` on the changed package are green (`internal/parser/parser.go` is flagged by gofmt but is pre-existing on `main` and untouched here).

[EN-1117]: https://formance-team.atlassian.net/browse/EN-1117?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ