### PR TITLE
fix: recover from panics in LSP request handling

### DIFF
--- a/internal/jsonrpc2/jsonrpc2.go
+++ b/internal/jsonrpc2/jsonrpc2.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"runtime/debug"
 	"sync"
 	"sync/atomic"
 
@@ -50,6 +51,21 @@ func NewRequestHandler[Params any](method string, strategy HandlingStrategy, han
 	return Handler{
 		register: func(conn *Conn) {
 			requestHandler := func(id ID, raw json.RawMessage) {
+				// Recover from panics in the handler so that a single faulty
+				// request doesn't kill the whole server process. The client
+				// receives a JSON-RPC internal error instead.
+				defer func() {
+					if recovered := recover(); recovered != nil {
+						log.Printf("jsonrpc2: recovered from panic while handling request %q: %v\n%s", method, recovered, debug.Stack())
+						if err := conn.stream.WriteMessage(Response{
+							ID:    id,
+							Error: &ErrInternal,
+						}); err != nil {
+							log.Printf("jsonrpc2: error writing internal error response: %v", err)
+						}
+					}
+				}()
+
 				var payload Params
 				if raw != nil {
 					err := json.Unmarshal([]byte(raw), &payload)
@@ -102,6 +118,16 @@ func NewNotificationHandler[Params any](method string, strategy HandlingStrategy
 	return Handler{
 		register: func(conn *Conn) {
 			notificationHandler := func(raw json.RawMessage) {
+				// Recover from panics in the handler so that a single faulty
+				// notification doesn't kill the whole server process.
+				// As per the json-rpc2 specs, notifications never get a response,
+				// so we only log the panic.
+				defer func() {
+					if recovered := recover(); recovered != nil {
+						log.Printf("jsonrpc2: recovered from panic while handling notification %q: %v\n%s", method, recovered, debug.Stack())
+					}
+				}()
+
 				var payload Params
 				err := json.Unmarshal([]byte(raw), &payload)
 				if err != nil {

--- a/internal/jsonrpc2/jsonrpc2_test.go
+++ b/internal/jsonrpc2/jsonrpc2_test.go
@@ -67,6 +67,70 @@ func TestErrIvalidParam(t *testing.T) {
 	require.Equal(t, &jsonrpc2.ErrInvalidParams, err)
 }
 
+func TestPanickingRequestHandlerReturnsInternalError(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		strategy jsonrpc2.HandlingStrategy
+	}{
+		{name: "sync", strategy: jsonrpc2.SyncHandling},
+		{name: "async", strategy: jsonrpc2.AsyncHandling},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			client := newClient(
+				jsonrpc2.NewRequestHandler("boom", tc.strategy, func(p struct{}, conn *jsonrpc2.Conn) any {
+					panic("handler exploded")
+				}),
+				jsonrpc2.NewRequestHandler("echo", tc.strategy, func(p string, conn *jsonrpc2.Conn) any {
+					return p
+				}),
+			)
+
+			// the panicking handler returns an internal error instead of killing the server
+			_, err := client.SendRequest("boom", struct{}{})
+			require.Equal(t, &jsonrpc2.ErrInternal, err)
+
+			// the connection survived the panic and still serves requests
+			raw, err := client.SendRequest("echo", "still alive")
+			require.Nil(t, err)
+
+			var res string
+			require.NoError(t, json.Unmarshal(raw, &res))
+			require.Equal(t, "still alive", res)
+		})
+	}
+}
+
+func TestPanickingNotificationHandlerKeepsConnAlive(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		strategy jsonrpc2.HandlingStrategy
+	}{
+		{name: "sync", strategy: jsonrpc2.SyncHandling},
+		{name: "async", strategy: jsonrpc2.AsyncHandling},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			client := newClient(
+				jsonrpc2.NewNotificationHandler("boom", tc.strategy, func(p struct{}, conn *jsonrpc2.Conn) {
+					panic("handler exploded")
+				}),
+				jsonrpc2.NewRequestHandler("echo", tc.strategy, func(p string, conn *jsonrpc2.Conn) any {
+					return p
+				}),
+			)
+
+			require.NoError(t, client.SendNotification("boom", struct{}{}))
+
+			// the connection survived the panic and still serves requests
+			raw, err := client.SendRequest("echo", "still alive")
+			require.Nil(t, err)
+
+			var res string
+			require.NoError(t, json.Unmarshal(raw, &res))
+			require.Equal(t, "still alive", res)
+		})
+	}
+}
+
 func newClient(serverHandlers ...jsonrpc2.Handler) *jsonrpc2.Conn {
 	in := make(chan jsonrpc2.Message)
 	out := make(chan jsonrpc2.Message)

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -294,7 +294,13 @@ func ParsePercentageRatio(source string) (*big.Int, int, error) {
 func parsePercentageRatio(source string, range_ Range) *PercentageLiteral {
 	num, floatingDigits, err := ParsePercentageRatio(source)
 	if err != nil {
-		panic(err)
+		// This should be unreachable for tokens emitted by the lexer.
+		// Degrade gracefully to a zero-value literal instead of panicking,
+		// so that a malformed token cannot crash the process (e.g. the LSP server).
+		return &PercentageLiteral{
+			Range:  range_,
+			Amount: big.NewInt(0),
+		}
 	}
 
 	return &PercentageLiteral{
@@ -570,7 +576,7 @@ func parseSaveStatement(saveCtx *antlrParser.SaveStatementContext) *SaveStatemen
 	return &SaveStatement{
 		Range:     ctxToRange(saveCtx),
 		SentValue: parseSentValue(saveCtx.SentValue()),
-		Account:    parseValueExpr(saveCtx.ValueExpr()),
+		Account:   parseValueExpr(saveCtx.ValueExpr()),
 	}
 }
 
@@ -630,7 +636,10 @@ func parseNumberLiteral(numNode antlr.TerminalNode) *NumberLiteral {
 
 	amt, ok := new(big.Int).SetString(amtStr, 10)
 	if !ok {
-		panic("Invalid number: " + amtStr)
+		// This should be unreachable for tokens emitted by the lexer.
+		// Degrade gracefully to a zero-value literal instead of panicking,
+		// so that a malformed token cannot crash the process (e.g. the LSP server).
+		amt = big.NewInt(0)
 	}
 
 	return &NumberLiteral{

--- a/internal/parser/parser_internal_test.go
+++ b/internal/parser/parser_internal_test.go
@@ -1,0 +1,32 @@
+package parser
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/antlr4-go/antlr/v4"
+	"github.com/stretchr/testify/require"
+)
+
+// These inputs should be unreachable through Parse() (the lexer only emits
+// well-formed tokens), but the parsing helpers must degrade gracefully to a
+// zero-value literal instead of panicking and killing the process.
+
+func TestParsePercentageRatioInvalidSourceDoesNotPanic(t *testing.T) {
+	require.NotPanics(t, func() {
+		lit := parsePercentageRatio("not a number%", Range{})
+		require.Equal(t, big.NewInt(0), lit.Amount)
+		require.Equal(t, 0, lit.FloatingDigits)
+	})
+}
+
+func TestParseNumberLiteralInvalidNumberDoesNotPanic(t *testing.T) {
+	tk := antlr.NewCommonToken(&antlr.TokenSourceCharStreamPair{}, 0, antlr.TokenDefaultChannel, 0, 0)
+	tk.SetText("_")
+	node := antlr.NewTerminalNodeImpl(tk)
+
+	require.NotPanics(t, func() {
+		lit := parseNumberLiteral(node)
+		require.Equal(t, big.NewInt(0), lit.Number)
+	})
+}


### PR DESCRIPTION
## Summary

Fixes [EN-1126](https://formance-team.atlassian.net/browse/EN-1126): the LSP/JSON-RPC server had no `recover()` anywhere in its request-handling path, so any panic in a handler killed the editor's language server process.

### Changes

- **`internal/jsonrpc2/jsonrpc2.go`**: add per-request panic recovery in the dispatch path.
  - Request handlers (both `SyncHandling` and `AsyncHandling`, since the async path wraps the same closure in a goroutine) now recover from panics, log the panic value + stack trace, and reply with a JSON-RPC internal error (`-32603`) instead of crashing the process. This also covers the `json.Marshal` panic on the handler's return value.
  - Notification handlers recover and log as well; per the JSON-RPC 2.0 spec, notifications never get a response.
- **`internal/parser/parser.go`**: convert two defensive panics into graceful degradation.
  - `parsePercentageRatio` returns a zero-value `PercentageLiteral` instead of `panic(err)` on a percentage-ratio parse failure.
  - `parseNumberLiteral` falls back to a zero `big.Int` instead of panicking on an invalid number literal.
  - Both cases should be unreachable for tokens emitted by the lexer, but they must not be able to crash the process (e.g. the LSP server).

### Tests

- `internal/jsonrpc2/jsonrpc2_test.go`: panicking request handlers (sync and async) return `ErrInternal` and the connection keeps serving subsequent requests; panicking notification handlers (sync and async) keep the connection alive.
- `internal/parser/parser_internal_test.go`: malformed percentage and number-literal inputs produce zero-value literals without panicking.

`go test ./...` and `gofmt -l .` are both green.

Note: the `CheckSource` nil-deref panic in `internal/analysis/check.go` is intentionally out of scope — it is fixed separately in EN-1116.

[EN-1126]: https://formance-team.atlassian.net/browse/EN-1126?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ