### PR TITLE
test(cli): cover telemetryEnabled opt-out logic

### DIFF
--- a/cmd/numscript/main.go
+++ b/cmd/numscript/main.go
@@ -15,16 +15,20 @@ import (
 // -ldflags "-X main.Version=0.0.1"
 var Version string = "develop"
 
-// telemetryEnabled reports whether crash reporting should be active.
-// Telemetry is disabled in development builds (Version == "develop")
-// and when the NUMSCRIPT_NO_TELEMETRY environment variable is set to
-// any non-empty value.
-func telemetryEnabled() bool {
-	return Version != "develop" && os.Getenv("NUMSCRIPT_NO_TELEMETRY") == ""
+// sentryDsn is the Sentry endpoint used for crash reporting in release
+// builds. It is a variable so tests can point it elsewhere.
+var sentryDsn = "https://b8b6cfd5dab95e1258d80963c3db73bf@o4504394442539008.ingest.us.sentry.io/4507623538884608"
+
+// telemetryEnabled reports whether crash reporting should be active for
+// the given build version. Telemetry is disabled in development builds
+// (version == "develop") and when the NUMSCRIPT_NO_TELEMETRY environment
+// variable is set to any non-empty value.
+func telemetryEnabled(version string) bool {
+	return version != "develop" && os.Getenv("NUMSCRIPT_NO_TELEMETRY") == ""
 }
 
 func recoverPanic() {
-	if !telemetryEnabled() {
+	if !telemetryEnabled(Version) {
 		return
 	}
 
@@ -39,18 +43,27 @@ func recoverPanic() {
 	sentry.Flush(2 * time.Second)
 }
 
-func main() {
-	if telemetryEnabled() {
-		if err := sentry.Init(sentry.ClientOptions{
-			Dsn:              "https://b8b6cfd5dab95e1258d80963c3db73bf@o4504394442539008.ingest.us.sentry.io/4507623538884608",
-			AttachStacktrace: true,
-		}); err != nil {
-			fmt.Fprintf(os.Stderr, "Failed to initialize Sentry: %v\n", err)
-		}
-
-		defer sentry.Flush(2 * time.Second)
+// setupCrashReporting initializes Sentry when telemetry is enabled for
+// the given build version, and returns a flush function the caller must
+// defer. It returns a no-op when telemetry is disabled.
+func setupCrashReporting(version string) func() {
+	if !telemetryEnabled(version) {
+		return func() {}
 	}
 
+	if err := sentry.Init(sentry.ClientOptions{
+		Dsn:              sentryDsn,
+		AttachStacktrace: true,
+	}); err != nil {
+		fmt.Fprintf(os.Stderr, "Failed to initialize Sentry: %v\n", err)
+	}
+
+	return func() { sentry.Flush(2 * time.Second) }
+}
+
+func main() {
+	flush := setupCrashReporting(Version)
+	defer flush()
 	defer recoverPanic()
 
 	cmd.Execute(cmd.CliOptions{

--- a/cmd/numscript/main_test.go
+++ b/cmd/numscript/main_test.go
@@ -1,0 +1,141 @@
+package main
+
+import (
+	"os"
+	"testing"
+)
+
+func TestTelemetryDisabledInDevelopBuilds(t *testing.T) {
+	t.Setenv("NUMSCRIPT_NO_TELEMETRY", "")
+
+	if telemetryEnabled("develop") {
+		t.Error("expected telemetry to be disabled when version is \"develop\"")
+	}
+}
+
+func TestTelemetryDisabledWhenOptOutVarIsSet(t *testing.T) {
+	for _, value := range []string{"1", "true", "anything"} {
+		t.Setenv("NUMSCRIPT_NO_TELEMETRY", value)
+
+		if telemetryEnabled("0.0.1") {
+			t.Errorf("expected telemetry to be disabled when NUMSCRIPT_NO_TELEMETRY=%q", value)
+		}
+	}
+}
+
+func TestTelemetryEnabledInReleaseBuildsByDefault(t *testing.T) {
+	// t.Setenv with an empty value ensures the variable is treated as
+	// unset by telemetryEnabled, and restores any pre-existing value
+	// from the test environment afterwards.
+	t.Setenv("NUMSCRIPT_NO_TELEMETRY", "")
+
+	if !telemetryEnabled("0.0.1") {
+		t.Error("expected telemetry to be enabled in release builds when NUMSCRIPT_NO_TELEMETRY is not set")
+	}
+}
+
+// setVersion overrides the build-time Version global for the duration of
+// a test and restores the previous value afterwards.
+func setVersion(t *testing.T, version string) {
+	t.Helper()
+	previous := Version
+	Version = version
+	t.Cleanup(func() { Version = previous })
+}
+
+// setSentryDsn overrides the Sentry DSN for the duration of a test so
+// that no real endpoint is ever configured.
+func setSentryDsn(t *testing.T, dsn string) {
+	t.Helper()
+	previous := sentryDsn
+	sentryDsn = dsn
+	t.Cleanup(func() { sentryDsn = previous })
+}
+
+// silenceStderr redirects os.Stderr to the null device for the duration
+// of a test, to keep expected error output out of the test logs.
+func silenceStderr(t *testing.T) {
+	t.Helper()
+	devNull, err := os.OpenFile(os.DevNull, os.O_WRONLY, 0)
+	if err != nil {
+		t.Fatalf("failed to open %s: %v", os.DevNull, err)
+	}
+	previous := os.Stderr
+	os.Stderr = devNull
+	t.Cleanup(func() {
+		os.Stderr = previous
+		_ = devNull.Close()
+	})
+}
+
+func TestSetupCrashReportingIsNoopWhenTelemetryDisabled(t *testing.T) {
+	t.Setenv("NUMSCRIPT_NO_TELEMETRY", "1")
+
+	flush := setupCrashReporting("0.0.1")
+	if flush == nil {
+		t.Fatal("expected a non-nil flush function")
+	}
+	flush()
+}
+
+func TestSetupCrashReportingInitializesSentryWhenEnabled(t *testing.T) {
+	t.Setenv("NUMSCRIPT_NO_TELEMETRY", "")
+	// An empty DSN makes sentry.Init succeed with a disabled client, so
+	// nothing is ever sent over the network.
+	setSentryDsn(t, "")
+
+	flush := setupCrashReporting("0.0.1")
+	if flush == nil {
+		t.Fatal("expected a non-nil flush function")
+	}
+	flush()
+}
+
+func TestSetupCrashReportingReportsInitErrors(t *testing.T) {
+	t.Setenv("NUMSCRIPT_NO_TELEMETRY", "")
+	setSentryDsn(t, "not-a-valid-dsn")
+	silenceStderr(t)
+
+	// Must not panic; the error is reported on stderr and execution
+	// continues without crash reporting.
+	flush := setupCrashReporting("0.0.1")
+	flush()
+}
+
+func TestRecoverPanicIsNoopWhenTelemetryDisabled(t *testing.T) {
+	setVersion(t, "0.0.1")
+	t.Setenv("NUMSCRIPT_NO_TELEMETRY", "1")
+
+	defer func() {
+		if recover() == nil {
+			t.Error("expected the panic to propagate when telemetry is disabled")
+		}
+	}()
+
+	defer recoverPanic()
+	panic("boom")
+}
+
+func TestRecoverPanicIsNoopWithoutPanic(t *testing.T) {
+	setVersion(t, "0.0.1")
+	t.Setenv("NUMSCRIPT_NO_TELEMETRY", "")
+
+	// Must not capture anything or crash when no panic occurred.
+	recoverPanic()
+}
+
+func TestRecoverPanicCapturesPanicWhenTelemetryEnabled(t *testing.T) {
+	setVersion(t, "0.0.1")
+	t.Setenv("NUMSCRIPT_NO_TELEMETRY", "")
+	// Bind a disabled Sentry client (empty DSN) to the global hub so
+	// CaptureMessage is guaranteed to be a no-op.
+	setSentryDsn(t, "")
+	setupCrashReporting("0.0.1")()
+	silenceStderr(t)
+
+	func() {
+		defer recoverPanic()
+		panic("boom")
+	}()
+	// Reaching this point means recoverPanic swallowed the panic.
+}


### PR DESCRIPTION
## Summary

Follow-up to #149 ([EN-1129](https://formance-team.atlassian.net/browse/EN-1129)): codecov flagged the #149 diff with 0.00% patch coverage because `cmd/numscript` (package main) had no tests.

This PR:

- Adds `cmd/numscript/main_test.go` covering `telemetryEnabled`:
  - develop version → telemetry disabled
  - release version with `NUMSCRIPT_NO_TELEMETRY` set (via `t.Setenv`) → disabled
  - release version without the variable → enabled
- Also covers `recoverPanic` (panic propagation when opted out, no-op without panic, capture path when enabled).
- Minimal testability refactor: `telemetryEnabled` now takes the version as a parameter, and the Sentry setup is extracted into `setupCrashReporting(version) func()` with the DSN in a package-level var so tests can use an empty DSN (sentry.Init with an empty DSN yields a disabled client — nothing is ever sent over the network from tests).

## Coverage

- `cmd/numscript` package coverage: 0% → 80.0% of statements (only `func main()` remains uncovered).
- Estimated patch coverage of the #149 + this diff in `main.go`: 9/12 executable lines = 75%, above the 67.14% patch target.

## Test plan

- `go build ./...` passes
- `go test ./...` passes
- `gofmt -l` clean on changed files

[EN-1129]: https://formance-team.atlassian.net/browse/EN-1129?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ