### PR TITLE
feat: re-export BalanceRow from the public package

### DIFF
--- a/numscript.go
+++ b/numscript.go
@@ -58,6 +58,7 @@ type (
 	MetadataQuery    = interpreter.MetadataQuery
 	AccountBalance   = interpreter.AccountBalance
 	Balances         = interpreter.Balances
+	BalanceRow       = interpreter.BalanceRow
 
 	AccountMetadata = interpreter.AccountMetadata
 


### PR DESCRIPTION
## Summary

`Balances` is exposed at the package level as `[]BalanceRow`, but `BalanceRow` itself lives in `internal/interpreter`. External `Store` implementations can therefore not construct an element of the slice without falling back to the slice-elision idiom:

```go
balances = append(balances, numscript.Balances{{
    Account: item.Account,
    Asset:   item.Asset,
    Color:   item.Color,
    Amount:  amount,
}}...)
```

Adding the alias closes the gap and keeps the public surface symmetric with the input side, where `BalanceQueryItem` is already re-exported.

Targets #160 since this completes the public API introduced there.

## Test plan
- [x] ` + "`" + `go build ./...` + "`" + ` on the numscript module
- [ ] Downstream consumer (ledger-v3-poc color-of-money branch) builds cleanly against this branch