### PR TITLE
feat(builder): add SrcAllowingUnboundedOverdraft combinator

### DIFF
--- a/builder/source.go
+++ b/builder/source.go
@@ -17,6 +17,19 @@ func SrcColored(
 	}
 }
 
+// SrcAllowingUnboundedOverdraft wraps a source (typically SrcAccount or
+// SrcColored) and appends the `allowing unbounded overdraft` clause, per the
+// Numscript grammar rule `srcAccountUnboundedOverdraft`
+// (address colorConstraint? ALLOWING UNBOUNDED OVERDRAFT). It lets a non-world
+// source go negative — required, for instance, when minting a colour the
+// account does not yet hold.
+func SrcAllowingUnboundedOverdraft(source Source) Source {
+	return func(env *env, w int) {
+		source(env, w)
+		env.builder.WriteString(" allowing unbounded overdraft")
+	}
+}
+
 func SrcInorder(sources ...Source) Source {
 	return func(env *env, w int) {
 		env.builder.WriteString("{\n")

--- a/builder/source_test.go
+++ b/builder/source_test.go
@@ -1,0 +1,40 @@
+package builder_test
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/formancehq/numscript/builder"
+	"github.com/gkampitakis/go-snaps/snaps"
+)
+
+func TestSrcAllowingUnboundedOverdraft(t *testing.T) {
+	stmt := builder.StmtSend(
+		builder.ExprMonetary(
+			builder.ExprAsset("USD/2"),
+			builder.ExprNumberBigInt(big.NewInt(100)),
+		),
+		builder.SrcAllowingUnboundedOverdraft(
+			builder.SrcColored(
+				builder.ExprAccount("tmp:acc"),
+				builder.ExprString("ABCDEF"),
+			),
+		),
+		builder.DestAccount(
+			builder.ExprAccount("dest"),
+		),
+	)
+
+	_, _, script := builder.BuildProgram(stmt)
+	snaps.MatchInlineSnapshot(t, script, snaps.Inline(`vars {
+  account $account_0
+  account $account_1
+  string $string_0
+  asset $asset_0
+}
+
+send [$asset_0 100] (
+  source = $account_0 \ $string_0 allowing unbounded overdraft
+  destination = $account_1
+)`))
+}


### PR DESCRIPTION
Adds the `allowing unbounded overdraft` source combinator on top of #163, required by transaction-plane EN-1271. Base is #163's branch.