### PR TITLE
fix(interpreter): implement Unwrap on query error types

### DIFF
--- a/internal/interpreter/interpreter_error.go
+++ b/internal/interpreter/interpreter_error.go
@@ -199,6 +199,10 @@ func (e QueryBalanceError) Error() string {
 	return e.WrappedError.Error()
 }
 
+func (e QueryBalanceError) Unwrap() error {
+	return e.WrappedError
+}
+
 type QueryMetadataError struct {
 	parser.Range
 	WrappedError error
@@ -206,6 +210,10 @@ type QueryMetadataError struct {
 
 func (e QueryMetadataError) Error() string {
 	return e.WrappedError.Error()
+}
+
+func (e QueryMetadataError) Unwrap() error {
+	return e.WrappedError
 }
 
 type ExperimentalFeature struct {


### PR DESCRIPTION
## What

Implement `Unwrap()` on `QueryBalanceError` and `QueryMetadataError`.

## Why

Both types wrap a store error (the error returned by `Store.GetBalances` / `Store.GetAccountsMetadata`) but only implemented `Error()`, which stringifies the wrapped error. Without `Unwrap()` the error chain is severed: `errors.Is` / `errors.As` cannot reach the wrapped cause, so a caller can only read the message, not classify the underlying error.

Implementing `Unwrap()` is the standard contract for a wrapping error and lets callers recover the store error's concrete type/sentinel through the chain.

## Impact

Behaviour-preserving for existing callers (`Error()` unchanged). Callers that want to classify a store failure surfaced through a balance/metadata query can now do so via `errors.Is`/`errors.As`.