### PR TITLE
fix: properly version json schemas

### DIFF
--- a/inputs.schema.json
+++ b/inputs.schema.json
@@ -21,35 +21,18 @@
   },
   "definitions": {
     "Balances": {
-      "type": "array",
-      "description": "List of account balances. The (account, asset, color, scope) tuple of each entry must be unique within the list.",
-      "items": { "$ref": "#/definitions/BalanceRow" }
-    },
-
-    "BalanceRow": {
       "type": "object",
-      "description": "The balance of a given (account, asset, color, scope)",
+      "description": "Map of account names to asset balances",
       "additionalProperties": false,
-      "required": ["account", "asset", "amount"],
-      "properties": {
-        "account": {
-          "type": "string",
-          "pattern": "^([a-zA-Z0-9_-]+(:[a-zA-Z0-9_-]+)*)$"
-        },
-        "asset": {
-          "type": "string",
-          "pattern": "^([A-Z]+(/[0-9]+)?)$"
-        },
-        "amount": {
-          "type": "number"
-        },
-        "color": {
-          "type": "string",
-          "pattern": "^[A-Z]*$"
-        },
-        "scope": {
-          "type": "string",
-          "pattern": "^[a-z0-9_]*$"
+      "patternProperties": {
+        "^([a-zA-Z0-9_-]+(:[a-zA-Z0-9_-]+)*)$": {
+          "type": "object",
+          "additionalProperties": false,
+          "patternProperties": {
+            "^([A-Z]+(/[0-9]+)?)$": {
+              "type": "number"
+            }
+          }
         }
       }
     },
@@ -64,32 +47,21 @@
     },
 
     "AccountsMetadata": {
-      "type": "array",
-      "description": "List of account metadata entries. The (account, key, scope) tuple of each entry must be unique within the list.",
-      "items": { "$ref": "#/definitions/AccountMetadataRow" }
-    },
-
-    "AccountMetadataRow": {
       "type": "object",
-      "description": "A single metadata entry: the value of a given (account, key, scope)",
+      "description": "Map of an account metadata to the account's metadata",
       "additionalProperties": false,
-      "required": ["account", "key", "value"],
-      "properties": {
-        "account": {
-          "type": "string",
-          "pattern": "^([a-zA-Z0-9_-]+(:[a-zA-Z0-9_-]+)*)$"
-        },
-        "key": {
-          "type": "string"
-        },
-        "value": {
-          "type": "string"
-        },
-        "scope": {
-          "type": "string",
-          "pattern": "^[a-z0-9_]*$"
+      "patternProperties": {
+        "^([a-zA-Z0-9_-]+(:[a-zA-Z0-9_-]+)*)$": {
+          "type": "object",
+          "additionalProperties": { "type": "string" }
         }
       }
+    },
+
+    "TxMetadata": {
+      "type": "object",
+      "description": "Map from a metadata's key to the transaction's metadata stringied value",
+      "additionalProperties": { "type": "string" }
     }
   }
 }

--- a/internal/cmd/test_init.go
+++ b/internal/cmd/test_init.go
@@ -161,7 +161,7 @@ func makeSpecsFile(
 	}
 
 	specs := specs_format.Specs{
-		Schema:       "https://raw.githubusercontent.com/formancehq/numscript/main/specs.schema.json",
+		Schema:       "https://raw.githubusercontent.com/formancehq/numscript/main/v1.specs.schema.json",
 		Balances:     store.StaticStore.Balances,
 		Vars:         vars,
 		FeatureFlags: featureFlags_,

--- a/internal/interpreter/testdata/numscript-cookbook/experimental/meta-calc.num.specs.json
+++ b/internal/interpreter/testdata/numscript-cookbook/experimental/meta-calc.num.specs.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/formancehq/numscript/main/specs.schema.json",
+  "$schema": "https://raw.githubusercontent.com/formancehq/numscript/main/v1.specs.schema.json",
   "featureFlags": [
     "experimental-overdraft-function",
     "experimental-mid-script-function-call",

--- a/internal/interpreter/testdata/numscript-cookbook/experimental/mixed-source-prefer-single-source.num.specs.json
+++ b/internal/interpreter/testdata/numscript-cookbook/experimental/mixed-source-prefer-single-source.num.specs.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/formancehq/numscript/main/specs.schema.json",
+  "$schema": "https://raw.githubusercontent.com/formancehq/numscript/main/v1.specs.schema.json",
   "variables": {
     "amt": "10"
   },

--- a/internal/interpreter/testdata/numscript-cookbook/experimental/top-up-many.num.specs.json
+++ b/internal/interpreter/testdata/numscript-cookbook/experimental/top-up-many.num.specs.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/formancehq/numscript/main/specs.schema.json",
+  "$schema": "https://raw.githubusercontent.com/formancehq/numscript/main/v1.specs.schema.json",
   "featureFlags": [
     "experimental-overdraft-function",
     "experimental-mid-script-function-call",

--- a/internal/interpreter/testdata/numscript-cookbook/experimental/top-up.num.specs.json
+++ b/internal/interpreter/testdata/numscript-cookbook/experimental/top-up.num.specs.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/formancehq/numscript/main/specs.schema.json",
+  "$schema": "https://raw.githubusercontent.com/formancehq/numscript/main/v1.specs.schema.json",
   "featureFlags": [
     "experimental-overdraft-function"
   ],

--- a/internal/interpreter/testdata/numscript-cookbook/experimental/transfer-example.num.specs.json
+++ b/internal/interpreter/testdata/numscript-cookbook/experimental/transfer-example.num.specs.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/formancehq/numscript/main/specs.schema.json",
+  "$schema": "https://raw.githubusercontent.com/formancehq/numscript/main/v1.specs.schema.json",
   "featureFlags": [
     "experimental-overdraft-function",
     "experimental-mid-script-function-call",

--- a/internal/interpreter/testdata/numscript-cookbook/max-fee.num.specs.json
+++ b/internal/interpreter/testdata/numscript-cookbook/max-fee.num.specs.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/formancehq/numscript/main/specs.schema.json",
+  "$schema": "https://raw.githubusercontent.com/formancehq/numscript/main/v1.specs.schema.json",
   "variables": {
     "cap": "10",
     "fee": "10%"

--- a/internal/interpreter/testdata/numscript-cookbook/mixed-source-dest-allotment.num.specs.json
+++ b/internal/interpreter/testdata/numscript-cookbook/mixed-source-dest-allotment.num.specs.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/formancehq/numscript/main/specs.schema.json",
+  "$schema": "https://raw.githubusercontent.com/formancehq/numscript/main/v1.specs.schema.json",
   "testCases": [
     {
       "it": "matches sources and destinations allotments",

--- a/internal/interpreter/testdata/numscript-cookbook/send-max.num.specs.json
+++ b/internal/interpreter/testdata/numscript-cookbook/send-max.num.specs.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/formancehq/numscript/main/specs.schema.json",
+  "$schema": "https://raw.githubusercontent.com/formancehq/numscript/main/v1.specs.schema.json",
   "testCases": [
     {
       "it": "is capped to USD100 when balance is higher",

--- a/internal/interpreter/testdata/numscript-cookbook/top-up-max.num.specs.json
+++ b/internal/interpreter/testdata/numscript-cookbook/top-up-max.num.specs.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/formancehq/numscript/main/specs.schema.json",
+  "$schema": "https://raw.githubusercontent.com/formancehq/numscript/main/v1.specs.schema.json",
   "variables": {
     "amt": "EUR/2 100",
     "limit": "EUR/2 150"

--- a/internal/interpreter/testdata/script-tests/bigint-literal.num.specs.json
+++ b/internal/interpreter/testdata/script-tests/bigint-literal.num.specs.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/formancehq/numscript/main/specs.schema.json",
+  "$schema": "https://raw.githubusercontent.com/formancehq/numscript/main/v1.specs.schema.json",
   "testCases": [
     {
       "it": "example spec",

--- a/internal/interpreter/testdata/script-tests/experimental/asset-scaling/no-solution.num.specs.json
+++ b/internal/interpreter/testdata/script-tests/experimental/asset-scaling/no-solution.num.specs.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/formancehq/numscript/main/specs.schema.json",
+  "$schema": "https://raw.githubusercontent.com/formancehq/numscript/main/v1.specs.schema.json",
   "featureFlags": [
     "experimental-asset-scaling"
   ],

--- a/internal/interpreter/testdata/script-tests/experimental/asset-scaling/scaling-all-allotment.num.specs.json
+++ b/internal/interpreter/testdata/script-tests/experimental/asset-scaling/scaling-all-allotment.num.specs.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/formancehq/numscript/main/specs.schema.json",
+  "$schema": "https://raw.githubusercontent.com/formancehq/numscript/main/v1.specs.schema.json",
   "featureFlags": [
     "experimental-asset-scaling"
   ],

--- a/internal/interpreter/testdata/script-tests/experimental/asset-scaling/scaling-allotment.num.specs.json
+++ b/internal/interpreter/testdata/script-tests/experimental/asset-scaling/scaling-allotment.num.specs.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/formancehq/numscript/main/specs.schema.json",
+  "$schema": "https://raw.githubusercontent.com/formancehq/numscript/main/v1.specs.schema.json",
   "featureFlags": [
     "experimental-asset-scaling"
   ],

--- a/internal/interpreter/testdata/script-tests/experimental/asset-scaling/scaling-kept.num.specs.json
+++ b/internal/interpreter/testdata/script-tests/experimental/asset-scaling/scaling-kept.num.specs.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/formancehq/numscript/main/specs.schema.json",
+  "$schema": "https://raw.githubusercontent.com/formancehq/numscript/main/v1.specs.schema.json",
   "featureFlags": [
     "experimental-asset-scaling"
   ],

--- a/internal/interpreter/testdata/script-tests/experimental/asset-scaling/scaling-send-all.num.specs.json
+++ b/internal/interpreter/testdata/script-tests/experimental/asset-scaling/scaling-send-all.num.specs.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/formancehq/numscript/main/specs.schema.json",
+  "$schema": "https://raw.githubusercontent.com/formancehq/numscript/main/v1.specs.schema.json",
   "featureFlags": [
     "experimental-asset-scaling"
   ],

--- a/internal/interpreter/testdata/script-tests/experimental/asset-scaling/scaling-with-oneof.num.specs.json
+++ b/internal/interpreter/testdata/script-tests/experimental/asset-scaling/scaling-with-oneof.num.specs.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/formancehq/numscript/main/specs.schema.json",
+  "$schema": "https://raw.githubusercontent.com/formancehq/numscript/main/v1.specs.schema.json",
   "featureFlags": [
     "experimental-oneof",
     "experimental-asset-scaling"

--- a/internal/interpreter/testdata/script-tests/experimental/asset-scaling/scaling.num.specs.json
+++ b/internal/interpreter/testdata/script-tests/experimental/asset-scaling/scaling.num.specs.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/formancehq/numscript/main/specs.schema.json",
+  "$schema": "https://raw.githubusercontent.com/formancehq/numscript/main/v1.specs.schema.json",
   "featureFlags": [
     "experimental-asset-scaling"
   ],

--- a/internal/interpreter/testdata/script-tests/experimental/asset-scaling/update-swap-account-balance.num.specs.json
+++ b/internal/interpreter/testdata/script-tests/experimental/asset-scaling/update-swap-account-balance.num.specs.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/formancehq/numscript/main/specs.schema.json",
+  "$schema": "https://raw.githubusercontent.com/formancehq/numscript/main/v1.specs.schema.json",
   "featureFlags": [
     "experimental-asset-scaling"
   ],

--- a/internal/interpreter/testdata/script-tests/experimental/scoped-function/allotment.num.specs.json
+++ b/internal/interpreter/testdata/script-tests/experimental/scoped-function/allotment.num.specs.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/formancehq/numscript/main/specs.schema.json",
+  "$schema": "https://raw.githubusercontent.com/formancehq/numscript/main/v1.specs.schema.json",
   "featureFlags": [
     "experimental-scoped-function",
     "experimental-mid-script-function-call"

--- a/internal/interpreter/testdata/script-tests/experimental/scoped-function/balance.num.specs.json
+++ b/internal/interpreter/testdata/script-tests/experimental/scoped-function/balance.num.specs.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/formancehq/numscript/main/specs.schema.json",
+  "$schema": "https://raw.githubusercontent.com/formancehq/numscript/main/v1.specs.schema.json",
   "featureFlags": ["experimental-scoped-function", "experimental-mid-script-function-call"],
   "balances": [
     { "account": "treasury", "asset": "EUR/2", "amount": 42 },

--- a/internal/interpreter/testdata/script-tests/experimental/scoped-function/capped.num.specs.json
+++ b/internal/interpreter/testdata/script-tests/experimental/scoped-function/capped.num.specs.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/formancehq/numscript/main/specs.schema.json",
+  "$schema": "https://raw.githubusercontent.com/formancehq/numscript/main/v1.specs.schema.json",
   "featureFlags": [
     "experimental-scoped-function",
     "experimental-mid-script-function-call"

--- a/internal/interpreter/testdata/script-tests/experimental/scoped-function/color-and-scope.num.specs.json
+++ b/internal/interpreter/testdata/script-tests/experimental/scoped-function/color-and-scope.num.specs.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/formancehq/numscript/main/specs.schema.json",
+  "$schema": "https://raw.githubusercontent.com/formancehq/numscript/main/v1.specs.schema.json",
   "featureFlags": [
     "experimental-scoped-function",
     "experimental-mid-script-function-call",

--- a/internal/interpreter/testdata/script-tests/experimental/scoped-function/overdraft.num.specs.json
+++ b/internal/interpreter/testdata/script-tests/experimental/scoped-function/overdraft.num.specs.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/formancehq/numscript/main/specs.schema.json",
+  "$schema": "https://raw.githubusercontent.com/formancehq/numscript/main/v1.specs.schema.json",
   "featureFlags": [
     "experimental-scoped-function",
     "experimental-mid-script-function-call"

--- a/internal/interpreter/testdata/script-tests/experimental/scoped-function/read-account-meta.num.specs.json
+++ b/internal/interpreter/testdata/script-tests/experimental/scoped-function/read-account-meta.num.specs.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/formancehq/numscript/main/specs.schema.json",
+  "$schema": "https://raw.githubusercontent.com/formancehq/numscript/main/v1.specs.schema.json",
   "featureFlags": [
     "experimental-scoped-function",
     "experimental-mid-script-function-call"

--- a/internal/interpreter/testdata/script-tests/experimental/scoped-function/save.num.specs.json
+++ b/internal/interpreter/testdata/script-tests/experimental/scoped-function/save.num.specs.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/formancehq/numscript/main/specs.schema.json",
+  "$schema": "https://raw.githubusercontent.com/formancehq/numscript/main/v1.specs.schema.json",
   "featureFlags": [
     "experimental-scoped-function",
     "experimental-mid-script-function-call"

--- a/internal/interpreter/testdata/script-tests/experimental/scoped-function/set-account-meta.num.specs.json
+++ b/internal/interpreter/testdata/script-tests/experimental/scoped-function/set-account-meta.num.specs.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/formancehq/numscript/main/specs.schema.json",
+  "$schema": "https://raw.githubusercontent.com/formancehq/numscript/main/v1.specs.schema.json",
   "featureFlags": [
     "experimental-mid-script-function-call",
     "experimental-scoped-function"

--- a/internal/interpreter/testdata/script-tests/experimental/scoped-function/simple.num.specs.json
+++ b/internal/interpreter/testdata/script-tests/experimental/scoped-function/simple.num.specs.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/formancehq/numscript/main/specs.schema.json",
+  "$schema": "https://raw.githubusercontent.com/formancehq/numscript/main/v1.specs.schema.json",
   "balances": [
     {
       "account": "src",

--- a/internal/interpreter/testdata/script-tests/feature-flag-syntax.num.specs.json
+++ b/internal/interpreter/testdata/script-tests/feature-flag-syntax.num.specs.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/formancehq/numscript/main/specs.schema.json",
+  "$schema": "https://raw.githubusercontent.com/formancehq/numscript/main/v1.specs.schema.json",
   "balances": [
     {
       "account": "acc",

--- a/internal/interpreter/testdata/script-tests/floating-perc.num.specs.json
+++ b/internal/interpreter/testdata/script-tests/floating-perc.num.specs.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "../../../../specs.schema.json",
+  "$schema": "../../../../v1.specs.schema.json",
   "testCases": [
     {
       "it": "should handle the floating syntax",

--- a/internal/interpreter/testdata/script-tests/floating-perc2.num.specs.json
+++ b/internal/interpreter/testdata/script-tests/floating-perc2.num.specs.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/formancehq/numscript/main/specs.schema.json",
+  "$schema": "https://raw.githubusercontent.com/formancehq/numscript/main/v1.specs.schema.json",
   "testCases": [
     {
       "it": "example spec",

--- a/internal/interpreter/testdata/script-tests/minus-infix-monetary.num.specs.json
+++ b/internal/interpreter/testdata/script-tests/minus-infix-monetary.num.specs.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/formancehq/numscript/main/specs.schema.json",
+  "$schema": "https://raw.githubusercontent.com/formancehq/numscript/main/v1.specs.schema.json",
   "testCases": [
     {
       "it": "should subtract the monetaries",

--- a/internal/interpreter/testdata/script-tests/minus-infix-number.num.specs.json
+++ b/internal/interpreter/testdata/script-tests/minus-infix-number.num.specs.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/formancehq/numscript/main/specs.schema.json",
+  "$schema": "https://raw.githubusercontent.com/formancehq/numscript/main/v1.specs.schema.json",
   "testCases": [
     {
       "it": "should subtract the numbers",

--- a/internal/interpreter/testdata/script-tests/minus-prefix-number.num.specs.json
+++ b/internal/interpreter/testdata/script-tests/minus-prefix-number.num.specs.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/formancehq/numscript/main/specs.schema.json",
+  "$schema": "https://raw.githubusercontent.com/formancehq/numscript/main/v1.specs.schema.json",
   "testCases": [
     {
       "it": "should subtract the numbers",

--- a/specs.schema.json
+++ b/specs.schema.json
@@ -73,7 +73,7 @@
         },
 
         "expect.metadata": {
-          "$ref": "#/definitions/SetAccountsMetadata"
+          "$ref": "#/definitions/AccountsMetadata"
         },
 
         "expect.error.missingFunds": {
@@ -83,35 +83,18 @@
     },
 
     "Balances": {
-      "type": "array",
-      "description": "List of account balances. The (account, asset, color, scope) tuple of each entry must be unique within the list.",
-      "items": { "$ref": "#/definitions/BalanceRow" }
-    },
-
-    "BalanceRow": {
       "type": "object",
-      "description": "The balance of a given (account, asset, color, scope)",
+      "description": "Map of account names to asset balances",
       "additionalProperties": false,
-      "required": ["account", "asset", "amount"],
-      "properties": {
-        "account": {
-          "type": "string",
-          "pattern": "^([a-zA-Z0-9_-]+(:[a-zA-Z0-9_-]+)*)$"
-        },
-        "asset": {
-          "type": "string",
-          "pattern": "^([A-Z]+(/[0-9]+)?)$"
-        },
-        "amount": {
-          "type": "number"
-        },
-        "color": {
-          "type": "string",
-          "pattern": "^[A-Z]*$"
-        },
-        "scope": {
-          "type": "string",
-          "pattern": "^[a-z0-9_]*$"
+      "patternProperties": {
+        "^([a-zA-Z0-9_-]+(:[a-zA-Z0-9_-]+)*)$": {
+          "type": "object",
+          "additionalProperties": false,
+          "patternProperties": {
+            "^([A-Z]+(/[0-9]+)?)$": {
+              "type": "number"
+            }
+          }
         }
       }
     },
@@ -126,180 +109,41 @@
     },
 
     "AccountsMetadata": {
-      "type": "array",
-      "description": "List of account metadata entries. The (account, key, scope) tuple of each entry must be unique within the list.",
-      "items": { "$ref": "#/definitions/AccountMetadataRow" }
-    },
-
-    "AccountMetadataRow": {
       "type": "object",
-      "description": "A single input metadata entry: the (opaque, string) value of a given (account, key, scope)",
+      "description": "Map of an account metadata to the account's metadata",
       "additionalProperties": false,
-      "required": ["account", "key", "value"],
-      "properties": {
-        "account": {
-          "type": "string",
-          "pattern": "^([a-zA-Z0-9_-]+(:[a-zA-Z0-9_-]+)*)$"
-        },
-        "key": {
-          "type": "string"
-        },
-        "value": {
-          "type": "string"
-        },
-        "scope": {
-          "type": "string",
-          "pattern": "^[a-z0-9_]*$"
-        }
-      }
-    },
-
-    "SetAccountsMetadata": {
-      "type": "array",
-      "description": "List of account metadata entries set during execution. Each value is a tagged value.",
-      "items": { "$ref": "#/definitions/SetAccountMetadataRow" }
-    },
-
-    "SetAccountMetadataRow": {
-      "type": "object",
-      "description": "A single set metadata entry: the tagged value of a given (account, key, scope)",
-      "additionalProperties": false,
-      "required": ["account", "key", "value"],
-      "properties": {
-        "account": {
-          "type": "string",
-          "pattern": "^([a-zA-Z0-9_-]+(:[a-zA-Z0-9_-]+)*)$"
-        },
-        "key": {
-          "type": "string"
-        },
-        "value": {
-          "$ref": "#/definitions/Value"
-        },
-        "scope": {
-          "type": "string",
-          "pattern": "^[a-z0-9_]*$"
+      "patternProperties": {
+        "^([a-zA-Z0-9_-]+(:[a-zA-Z0-9_-]+)*)$": {
+          "type": "object",
+          "additionalProperties": { "type": "string" }
         }
       }
     },
 
     "TxMetadata": {
-      "type": "array",
-      "description": "List of transaction metadata entries set during execution. The key of each entry must be unique within the list.",
-      "items": { "$ref": "#/definitions/TxMetadataRow" }
-    },
-
-    "TxMetadataRow": {
       "type": "object",
-      "description": "A single transaction metadata entry: the tagged value of a given key",
-      "additionalProperties": false,
-      "required": ["key", "value"],
-      "properties": {
-        "key": {
-          "type": "string"
-        },
-        "value": {
-          "$ref": "#/definitions/Value"
-        }
-      }
-    },
-
-    "Value": {
-      "type": "object",
-      "description": "A tagged value, discriminated by its \"type\"",
-      "oneOf": [
-        {
-          "additionalProperties": false,
-          "required": ["type", "value"],
-          "properties": {
-            "type": { "const": "string" },
-            "value": { "type": "string" }
-          }
-        },
-        {
-          "additionalProperties": false,
-          "required": ["type", "value"],
-          "properties": {
-            "type": { "const": "number" },
-            "value": { "type": "string", "pattern": "^-?[0-9]+$" }
-          }
-        },
-        {
-          "additionalProperties": false,
-          "required": ["type", "name"],
-          "properties": {
-            "type": { "const": "asset" },
-            "name": { "type": "string", "pattern": "^([A-Z]+(/[0-9]+)?)$" }
-          }
-        },
-        {
-          "additionalProperties": false,
-          "required": ["type", "name"],
-          "properties": {
-            "type": { "const": "account" },
-            "name": { "type": "string", "pattern": "^([a-zA-Z0-9_-]+(:[a-zA-Z0-9_-]+)*)$" },
-            "scope": { "type": "string", "pattern": "^[a-z0-9_]*$" }
-          }
-        },
-        {
-          "additionalProperties": false,
-          "required": ["type", "asset", "amount"],
-          "properties": {
-            "type": { "const": "monetary" },
-            "asset": { "type": "string", "pattern": "^([A-Z]+(/[0-9]+)?)$" },
-            "amount": { "type": "string", "pattern": "^-?[0-9]+$" }
-          }
-        },
-        {
-          "additionalProperties": false,
-          "required": ["type", "numerator", "denominator"],
-          "properties": {
-            "type": { "const": "portion" },
-            "numerator": { "type": "string", "pattern": "^-?[0-9]+$" },
-            "denominator": { "type": "string", "pattern": "^-?[0-9]+$" }
-          }
-        }
-      ]
+      "description": "Map from a metadata's key to the transaction's metadata stringied value",
+      "additionalProperties": { "type": "string" }
     },
 
     "Movements": {
-      "type": "array",
-      "description": "List of funds sent from an account to another. The (source, sourceScope, destination, destinationScope, asset, color) tuple of each entry must be unique within the list.",
-      "items": { "$ref": "#/definitions/Movement" }
-    },
-
-    "Movement": {
       "type": "object",
-      "description": "The funds sent from an account to another for a given (asset, color)",
+      "description": "The funds sent from an account to another",
       "additionalProperties": false,
-      "required": ["source", "destination", "asset", "amount"],
-      "properties": {
-        "source": {
-          "type": "string",
-          "pattern": "^([a-zA-Z0-9_-]+(:[a-zA-Z0-9_-]+)*)$"
-        },
-        "sourceScope": {
-          "type": "string",
-          "pattern": "^[a-z0-9_]*$"
-        },
-        "destination": {
-          "type": "string",
-          "pattern": "^([a-zA-Z0-9_-]+(:[a-zA-Z0-9_-]+)*)$"
-        },
-        "destinationScope": {
-          "type": "string",
-          "pattern": "^[a-z0-9_]*$"
-        },
-        "asset": {
-          "type": "string",
-          "pattern": "^([A-Z]+(/[0-9]+)?)$"
-        },
-        "amount": {
-          "type": "number"
-        },
-        "color": {
-          "type": "string",
-          "pattern": "^[A-Z]*$"
+      "patternProperties": {
+        "^([a-zA-Z0-9_-]+(:[a-zA-Z0-9_-]+)*)$": {
+          "type": "object",
+          "additionalProperties": false,
+          "patternProperties": {
+            "^([a-zA-Z0-9_-]+(:[a-zA-Z0-9_-]+)*)$": {
+              "type": "object",
+              "patternProperties": {
+                "^([A-Z]+(/[0-9]+)?)$": {
+                  "type": "number"
+                }
+              }
+            }
+          }
         }
       }
     },
@@ -308,25 +152,13 @@
       "type": "object",
       "properties": {
         "source": { "type": "string" },
-        "sourceScope": {
-          "type": "string",
-          "pattern": "^[a-z0-9_]*$"
-        },
         "destination": { "type": "string" },
-        "destinationScope": {
-          "type": "string",
-          "pattern": "^[a-z0-9_]*$"
-        },
         "asset": {
           "type": "string",
           "pattern": "^([A-Z]+(/[0-9]+)?)$"
         },
         "amount": {
           "type": "number"
-        },
-        "color": {
-          "type": "string",
-          "pattern": "^[A-Z]*$"
         }
       },
       "required": ["source", "destination", "asset", "amount"]

--- a/v1.inputs.schema.json
+++ b/v1.inputs.schema.json
@@ -1,0 +1,95 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Specs",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "$schema": { "type": "string" },
+    "balances": {
+      "$ref": "#/definitions/Balances"
+    },
+    "variables": {
+      "$ref": "#/definitions/VariablesMap"
+    },
+    "metadata": {
+      "$ref": "#/definitions/AccountsMetadata"
+    },
+    "featureFlags": {
+      "type": "array",
+      "items": { "type": "string" }
+    }
+  },
+  "definitions": {
+    "Balances": {
+      "type": "array",
+      "description": "List of account balances. The (account, asset, color, scope) tuple of each entry must be unique within the list.",
+      "items": { "$ref": "#/definitions/BalanceRow" }
+    },
+
+    "BalanceRow": {
+      "type": "object",
+      "description": "The balance of a given (account, asset, color, scope)",
+      "additionalProperties": false,
+      "required": ["account", "asset", "amount"],
+      "properties": {
+        "account": {
+          "type": "string",
+          "pattern": "^([a-zA-Z0-9_-]+(:[a-zA-Z0-9_-]+)*)$"
+        },
+        "asset": {
+          "type": "string",
+          "pattern": "^([A-Z]+(/[0-9]+)?)$"
+        },
+        "amount": {
+          "type": "number"
+        },
+        "color": {
+          "type": "string",
+          "pattern": "^[A-Z]*$"
+        },
+        "scope": {
+          "type": "string",
+          "pattern": "^[a-z0-9_]*$"
+        }
+      }
+    },
+
+    "VariablesMap": {
+      "type": "object",
+      "description": "Map of variable name to variable stringified value",
+      "additionalProperties": false,
+      "patternProperties": {
+        "^[a-z_]+$": { "type": "string" }
+      }
+    },
+
+    "AccountsMetadata": {
+      "type": "array",
+      "description": "List of account metadata entries. The (account, key, scope) tuple of each entry must be unique within the list.",
+      "items": { "$ref": "#/definitions/AccountMetadataRow" }
+    },
+
+    "AccountMetadataRow": {
+      "type": "object",
+      "description": "A single metadata entry: the value of a given (account, key, scope)",
+      "additionalProperties": false,
+      "required": ["account", "key", "value"],
+      "properties": {
+        "account": {
+          "type": "string",
+          "pattern": "^([a-zA-Z0-9_-]+(:[a-zA-Z0-9_-]+)*)$"
+        },
+        "key": {
+          "type": "string"
+        },
+        "value": {
+          "type": "string"
+        },
+        "scope": {
+          "type": "string",
+          "pattern": "^[a-z0-9_]*$"
+        }
+      }
+    }
+  }
+}

--- a/v1.specs.schema.json
+++ b/v1.specs.schema.json
@@ -1,0 +1,335 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Specs",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["testCases"],
+  "properties": {
+    "$schema": { "type": "string" },
+    "balances": {
+      "$ref": "#/definitions/Balances"
+    },
+    "variables": {
+      "$ref": "#/definitions/VariablesMap"
+    },
+    "metadata": {
+      "$ref": "#/definitions/AccountsMetadata"
+    },
+    "testCases": {
+      "type": "array",
+      "items": { "$ref": "#/definitions/TestCase" }
+    },
+    "featureFlags": {
+      "type": "array",
+      "items": { "type": "string" }
+    }
+  },
+  "definitions": {
+    "TestCase": {
+      "type": "object",
+      "required": ["it"],
+      "additionalProperties": false,
+      "properties": {
+        "it": {
+          "type": "string",
+          "description": "Test case description"
+        },
+        "focus": {
+          "type": "boolean",
+          "description": "Skip all the other tests. Just for debugging: it will result in an error exit code"
+        },
+        "skip": {
+          "type": "boolean",
+          "description": "Skip this test. Just for debugging: it will result in an error exit code"
+        },
+
+        "balances": {
+          "$ref": "#/definitions/Balances"
+        },
+        "variables": {
+          "$ref": "#/definitions/VariablesMap"
+        },
+        "metadata": {
+          "$ref": "#/definitions/AccountsMetadata"
+        },
+        "expect.postings": {
+          "type": "array",
+          "items": { "$ref": "#/definitions/Posting" }
+        },
+
+        "expect.endBalances": {
+          "$ref": "#/definitions/Balances"
+        },
+        "expect.endBalances.include": {
+          "$ref": "#/definitions/Balances"
+        },
+
+        "expect.movements": {
+          "$ref": "#/definitions/Movements"
+        },
+
+        "expect.txMetadata": {
+          "$ref": "#/definitions/TxMetadata"
+        },
+
+        "expect.metadata": {
+          "$ref": "#/definitions/SetAccountsMetadata"
+        },
+
+        "expect.error.missingFunds": {
+          "type": "boolean"
+        }
+      }
+    },
+
+    "Balances": {
+      "type": "array",
+      "description": "List of account balances. The (account, asset, color, scope) tuple of each entry must be unique within the list.",
+      "items": { "$ref": "#/definitions/BalanceRow" }
+    },
+
+    "BalanceRow": {
+      "type": "object",
+      "description": "The balance of a given (account, asset, color, scope)",
+      "additionalProperties": false,
+      "required": ["account", "asset", "amount"],
+      "properties": {
+        "account": {
+          "type": "string",
+          "pattern": "^([a-zA-Z0-9_-]+(:[a-zA-Z0-9_-]+)*)$"
+        },
+        "asset": {
+          "type": "string",
+          "pattern": "^([A-Z]+(/[0-9]+)?)$"
+        },
+        "amount": {
+          "type": "number"
+        },
+        "color": {
+          "type": "string",
+          "pattern": "^[A-Z]*$"
+        },
+        "scope": {
+          "type": "string",
+          "pattern": "^[a-z0-9_]*$"
+        }
+      }
+    },
+
+    "VariablesMap": {
+      "type": "object",
+      "description": "Map of variable name to variable stringified value",
+      "additionalProperties": false,
+      "patternProperties": {
+        "^[a-z_]+$": { "type": "string" }
+      }
+    },
+
+    "AccountsMetadata": {
+      "type": "array",
+      "description": "List of account metadata entries. The (account, key, scope) tuple of each entry must be unique within the list.",
+      "items": { "$ref": "#/definitions/AccountMetadataRow" }
+    },
+
+    "AccountMetadataRow": {
+      "type": "object",
+      "description": "A single input metadata entry: the (opaque, string) value of a given (account, key, scope)",
+      "additionalProperties": false,
+      "required": ["account", "key", "value"],
+      "properties": {
+        "account": {
+          "type": "string",
+          "pattern": "^([a-zA-Z0-9_-]+(:[a-zA-Z0-9_-]+)*)$"
+        },
+        "key": {
+          "type": "string"
+        },
+        "value": {
+          "type": "string"
+        },
+        "scope": {
+          "type": "string",
+          "pattern": "^[a-z0-9_]*$"
+        }
+      }
+    },
+
+    "SetAccountsMetadata": {
+      "type": "array",
+      "description": "List of account metadata entries set during execution. Each value is a tagged value.",
+      "items": { "$ref": "#/definitions/SetAccountMetadataRow" }
+    },
+
+    "SetAccountMetadataRow": {
+      "type": "object",
+      "description": "A single set metadata entry: the tagged value of a given (account, key, scope)",
+      "additionalProperties": false,
+      "required": ["account", "key", "value"],
+      "properties": {
+        "account": {
+          "type": "string",
+          "pattern": "^([a-zA-Z0-9_-]+(:[a-zA-Z0-9_-]+)*)$"
+        },
+        "key": {
+          "type": "string"
+        },
+        "value": {
+          "$ref": "#/definitions/Value"
+        },
+        "scope": {
+          "type": "string",
+          "pattern": "^[a-z0-9_]*$"
+        }
+      }
+    },
+
+    "TxMetadata": {
+      "type": "array",
+      "description": "List of transaction metadata entries set during execution. The key of each entry must be unique within the list.",
+      "items": { "$ref": "#/definitions/TxMetadataRow" }
+    },
+
+    "TxMetadataRow": {
+      "type": "object",
+      "description": "A single transaction metadata entry: the tagged value of a given key",
+      "additionalProperties": false,
+      "required": ["key", "value"],
+      "properties": {
+        "key": {
+          "type": "string"
+        },
+        "value": {
+          "$ref": "#/definitions/Value"
+        }
+      }
+    },
+
+    "Value": {
+      "type": "object",
+      "description": "A tagged value, discriminated by its \"type\"",
+      "oneOf": [
+        {
+          "additionalProperties": false,
+          "required": ["type", "value"],
+          "properties": {
+            "type": { "const": "string" },
+            "value": { "type": "string" }
+          }
+        },
+        {
+          "additionalProperties": false,
+          "required": ["type", "value"],
+          "properties": {
+            "type": { "const": "number" },
+            "value": { "type": "string", "pattern": "^-?[0-9]+$" }
+          }
+        },
+        {
+          "additionalProperties": false,
+          "required": ["type", "name"],
+          "properties": {
+            "type": { "const": "asset" },
+            "name": { "type": "string", "pattern": "^([A-Z]+(/[0-9]+)?)$" }
+          }
+        },
+        {
+          "additionalProperties": false,
+          "required": ["type", "name"],
+          "properties": {
+            "type": { "const": "account" },
+            "name": { "type": "string", "pattern": "^([a-zA-Z0-9_-]+(:[a-zA-Z0-9_-]+)*)$" },
+            "scope": { "type": "string", "pattern": "^[a-z0-9_]*$" }
+          }
+        },
+        {
+          "additionalProperties": false,
+          "required": ["type", "asset", "amount"],
+          "properties": {
+            "type": { "const": "monetary" },
+            "asset": { "type": "string", "pattern": "^([A-Z]+(/[0-9]+)?)$" },
+            "amount": { "type": "string", "pattern": "^-?[0-9]+$" }
+          }
+        },
+        {
+          "additionalProperties": false,
+          "required": ["type", "numerator", "denominator"],
+          "properties": {
+            "type": { "const": "portion" },
+            "numerator": { "type": "string", "pattern": "^-?[0-9]+$" },
+            "denominator": { "type": "string", "pattern": "^-?[0-9]+$" }
+          }
+        }
+      ]
+    },
+
+    "Movements": {
+      "type": "array",
+      "description": "List of funds sent from an account to another. The (source, sourceScope, destination, destinationScope, asset, color) tuple of each entry must be unique within the list.",
+      "items": { "$ref": "#/definitions/Movement" }
+    },
+
+    "Movement": {
+      "type": "object",
+      "description": "The funds sent from an account to another for a given (asset, color)",
+      "additionalProperties": false,
+      "required": ["source", "destination", "asset", "amount"],
+      "properties": {
+        "source": {
+          "type": "string",
+          "pattern": "^([a-zA-Z0-9_-]+(:[a-zA-Z0-9_-]+)*)$"
+        },
+        "sourceScope": {
+          "type": "string",
+          "pattern": "^[a-z0-9_]*$"
+        },
+        "destination": {
+          "type": "string",
+          "pattern": "^([a-zA-Z0-9_-]+(:[a-zA-Z0-9_-]+)*)$"
+        },
+        "destinationScope": {
+          "type": "string",
+          "pattern": "^[a-z0-9_]*$"
+        },
+        "asset": {
+          "type": "string",
+          "pattern": "^([A-Z]+(/[0-9]+)?)$"
+        },
+        "amount": {
+          "type": "number"
+        },
+        "color": {
+          "type": "string",
+          "pattern": "^[A-Z]*$"
+        }
+      }
+    },
+
+    "Posting": {
+      "type": "object",
+      "properties": {
+        "source": { "type": "string" },
+        "sourceScope": {
+          "type": "string",
+          "pattern": "^[a-z0-9_]*$"
+        },
+        "destination": { "type": "string" },
+        "destinationScope": {
+          "type": "string",
+          "pattern": "^[a-z0-9_]*$"
+        },
+        "asset": {
+          "type": "string",
+          "pattern": "^([A-Z]+(/[0-9]+)?)$"
+        },
+        "amount": {
+          "type": "number"
+        },
+        "color": {
+          "type": "string",
+          "pattern": "^[A-Z]*$"
+        }
+      },
+      "required": ["source", "destination", "asset", "amount"]
+    }
+  }
+}


### PR DESCRIPTION
On the previous PRs we refactored the specs and inputs schema by doing breaking changes. The change isn't realised yet so it still doesn't break user codebases (and we are still in time to publish utilities to update the schema) but it will break editor diagnostics that use the $schema field.

Fixed it by adding a v1 prefix in the new format, so that we can leave the old format in the repo and user will be able to keep referring to that

---

Pr can be read commit by commit 