### PR TITLE
fix(mcp_impl): reject balance amounts beyond the safe JSON integer range

### DIFF
--- a/internal/mcp_impl/handlers.go
+++ b/internal/mcp_impl/handlers.go
@@ -25,6 +25,7 @@ func addEvalTool(s *server.MCPServer) {
 		mcp.WithArray("balances",
 			mcp.Required(),
 			mcp.Description(`The accounts' balances. A list of entries, each an object with an "account", an "asset", an integer "amount", an optional "color", and an optional "scope".
+			"amount" must be an integer with magnitude at most 2^50-1 (1125899906842623).
 			The (account, asset, color, scope) tuple of each entry must be unique within the list.
 			For example: [ { "account": "alice", "asset": "USD/2", "amount": 100 }, { "account": "alice", "asset": "EUR/2", "amount": -42 }, { "account": "bob", "asset": "BTC", "amount": 1 } ]
 			`),
@@ -48,15 +49,33 @@ func addEvalTool(s *server.MCPServer) {
 	s.AddTool(tool, handleEvalTool)
 }
 
-// maxExactJSONInt is the largest integer float64 can represent without loss
-// (2^53 - 1). The MCP transport decodes incoming JSON numbers into a generic
-// float64 (via Params.Arguments any) before this handler ever runs, so a
-// balance amount past this magnitude may already have been silently rounded
-// by the time BindArguments hands it to *big.Int - it will look like a
-// perfectly valid, exact integer at that point, indistinguishable from one
-// that was never corrupted. We can't recover the original value, so we
-// refuse to execute with one instead of risking a silently wrong balance.
-const maxExactJSONInt = float64(9_007_199_254_740_991)
+// maxExactJSONInt bounds the magnitude of balance amounts accepted from the
+// MCP transport. The MCP transport decodes incoming JSON numbers into a
+// generic float64 (via Params.Arguments any) before this handler ever runs,
+// so by the time BindArguments hands an amount to *big.Int, any precision
+// loss has already happened silently - a corrupted value looks exactly like
+// a genuine one, and we can't tell them apart or recover the original.
+//
+// float64 can represent every integer up to 2^53-1 exactly, so it may look
+// like that's the natural bound to check against. It isn't: float64's
+// *relative* precision is constant (~15-17 significant decimal digits)
+// regardless of magnitude, so a fractional amount can silently round away to
+// a whole number anywhere its magnitude is large enough relative to the size
+// of its fractional part - not just past 2^53-1. In particular, at any
+// magnitude >= 2^50 a single stray decimal digit (e.g. "9007199254740991.1")
+// already rounds cleanly to a whole number, defeating a check pinned to
+// 2^53-1. Below 2^50, float64's absolute precision is finer than 1, so a
+// single decimal digit of drift can no longer disappear into an adjacent
+// integer.
+//
+// Capping at 2^50-1 (instead of 2^53-1) trades range for that margin: it
+// rejects some magnitudes float64 could otherwise represent exactly, but
+// closes off the single-extra-digit corruption case. It is not a rigorous
+// guarantee - a value with enough fractional digits can still round away at
+// any nonzero magnitude - just a substantially safer margin than the
+// standard "MAX_SAFE_INTEGER" bound for the realistic case of a little
+// fractional drift on the client side.
+const maxExactJSONInt = float64((1 << 50) - 1)
 
 // checkBalanceAmountsInSafeRange rejects any "balances" entry whose amount
 // falls outside the range a JSON number can represent exactly. Must run
@@ -81,7 +100,7 @@ func checkBalanceAmountsInSafeRange(args map[string]any) *mcp.CallToolResult {
 
 		if amount < -maxExactJSONInt || amount > maxExactJSONInt {
 			return mcp.NewToolResultError(fmt.Sprintf(
-				"amount %v for account=%v asset=%v exceeds the range a JSON number can represent exactly (±(2^53-1)); it may have already lost precision before reaching the server",
+				"amount %v for account=%v asset=%v exceeds the range this server accepts (±(2^50-1)); it may have already lost precision before reaching the server",
 				amount, row["account"], row["asset"],
 			))
 		}

--- a/internal/mcp_impl/handlers.go
+++ b/internal/mcp_impl/handlers.go
@@ -48,6 +48,48 @@ func addEvalTool(s *server.MCPServer) {
 	s.AddTool(tool, handleEvalTool)
 }
 
+// maxExactJSONInt is the largest integer float64 can represent without loss
+// (2^53 - 1). The MCP transport decodes incoming JSON numbers into a generic
+// float64 (via Params.Arguments any) before this handler ever runs, so a
+// balance amount past this magnitude may already have been silently rounded
+// by the time BindArguments hands it to *big.Int - it will look like a
+// perfectly valid, exact integer at that point, indistinguishable from one
+// that was never corrupted. We can't recover the original value, so we
+// refuse to execute with one instead of risking a silently wrong balance.
+const maxExactJSONInt = float64(9_007_199_254_740_991)
+
+// checkBalanceAmountsInSafeRange rejects any "balances" entry whose amount
+// falls outside the range a JSON number can represent exactly. Must run
+// before the amount is converted to *big.Int, since that conversion can no
+// longer tell a corrupted value from a genuine one.
+func checkBalanceAmountsInSafeRange(args map[string]any) *mcp.CallToolResult {
+	balancesRaw, ok := args["balances"].([]any)
+	if !ok {
+		return nil
+	}
+
+	for _, rowRaw := range balancesRaw {
+		row, ok := rowRaw.(map[string]any)
+		if !ok {
+			continue
+		}
+
+		amount, ok := row["amount"].(float64)
+		if !ok {
+			continue
+		}
+
+		if amount < -maxExactJSONInt || amount > maxExactJSONInt {
+			return mcp.NewToolResultError(fmt.Sprintf(
+				"amount %v for account=%v asset=%v exceeds the range a JSON number can represent exactly (±(2^53-1)); it may have already lost precision before reaching the server",
+				amount, row["account"], row["asset"],
+			))
+		}
+	}
+
+	return nil
+}
+
 func handleEvalTool(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	script, err := request.RequireString("script")
 	if err != nil {
@@ -61,6 +103,10 @@ func handleEvalTool(ctx context.Context, request mcp.CallToolRequest) (*mcp.Call
 			out[index] = err.Msg
 		}
 		return mcp.NewToolResultError(strings.Join(out, ", ")), nil
+	}
+
+	if result := checkBalanceAmountsInSafeRange(request.GetArguments()); result != nil {
+		return result, nil
 	}
 
 	var args struct {

--- a/internal/mcp_impl/handlers.go
+++ b/internal/mcp_impl/handlers.go
@@ -25,10 +25,10 @@ func addEvalTool(s *server.MCPServer) {
 		),
 		mcp.WithArray("balances",
 			mcp.Required(),
-			mcp.Description(`The accounts' balances. A list of entries, each an object with an "account", an "asset", an integer "amount", an optional "color", and an optional "scope".
-			"amount" must be an integer with magnitude at most 2^50-1 (1125899906842623).
+			mcp.Description(`The accounts' balances. A list of entries, each an object with an "account", an "asset", an "amount", an optional "color", and an optional "scope".
+			"amount" must be passed as a string containing a base-10 integer (e.g. "100", not 100): JSON numbers only round-trip exactly up to 2^53-1, so an amount given as a JSON number can be silently corrupted in transit.
 			The (account, asset, color, scope) tuple of each entry must be unique within the list.
-			For example: [ { "account": "alice", "asset": "USD/2", "amount": 100 }, { "account": "alice", "asset": "EUR/2", "amount": -42 }, { "account": "bob", "asset": "BTC", "amount": 1 } ]
+			For example: [ { "account": "alice", "asset": "USD/2", "amount": "100" }, { "account": "alice", "asset": "EUR/2", "amount": "-42" }, { "account": "bob", "asset": "BTC", "amount": "1" } ]
 			`),
 		),
 		mcp.WithObject("vars",
@@ -50,21 +50,6 @@ func addEvalTool(s *server.MCPServer) {
 	s.AddTool(tool, handleEvalTool)
 }
 
-// maxBalanceAmount bounds the magnitude of balance amounts. The MCP
-// transport decodes incoming JSON numbers into a generic float64 (via
-// Params.Arguments any) before BindArguments converts one to *big.Int, so an
-// amount too large - or with enough fractional digits - can silently round
-// to a different, smaller-looking whole number first. float64 represents
-// every integer up to 2^53-1 exactly, but a fractional amount can still
-// round away to a whole number anywhere its magnitude is large relative to
-// its fractional part, not just past 2^53-1: e.g. at 2^50 or above, a single
-// stray decimal digit (like "9007199254740991.1") already rounds cleanly to
-// a whole number. Below 2^50, float64's absolute precision is finer than 1,
-// so that can no longer happen. Capping here (instead of at 2^53-1) trades
-// range for that margin; it's not a rigorous guarantee against enough
-// fractional digits at any magnitude, just a much safer one in practice.
-var maxBalanceAmount = big.NewInt((1 << 50) - 1)
-
 func handleEvalTool(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	script, err := request.RequireString("script")
 	if err != nil {
@@ -80,25 +65,46 @@ func handleEvalTool(ctx context.Context, request mcp.CallToolRequest) (*mcp.Call
 		return mcp.NewToolResultError(strings.Join(out, ", ")), nil
 	}
 
+	// balances are bound with a string Amount, not interpreter.Balances'
+	// *big.Int, so this never goes through the MCP transport's generic
+	// float64 argument decoding (Params.Arguments any): a JSON string
+	// round-trips through that decode byte for byte, unlike a JSON number,
+	// which can already be silently rounded - in magnitude or, at the right
+	// magnitude, in its fractional part - by the time a handler sees it.
 	var args struct {
-		Vars     map[string]string    `json:"vars"`
-		Balances interpreter.Balances `json:"balances"`
+		Vars     map[string]string `json:"vars"`
+		Balances []struct {
+			Account string `json:"account"`
+			Asset   string `json:"asset"`
+			Amount  string `json:"amount"`
+			Color   string `json:"color"`
+			Scope   string `json:"scope"`
+		} `json:"balances"`
 	}
 	err = request.BindArguments(&args)
 	if err != nil {
 		return mcp.NewToolResultError(err.Error()), nil
 	}
 
-	for _, row := range args.Balances {
-		if row.Amount.CmpAbs(maxBalanceAmount) > 0 {
+	balances := make(interpreter.Balances, len(args.Balances))
+	for i, row := range args.Balances {
+		amount, ok := new(big.Int).SetString(row.Amount, 10)
+		if !ok {
 			return mcp.NewToolResultError(fmt.Sprintf(
-				"amount %s for account=%q asset=%q exceeds the range this server accepts (±(2^50-1)); it may have already lost precision before reaching the server",
+				"amount %q for account=%q asset=%q is not a valid base-10 integer string",
 				row.Amount, row.Account, row.Asset,
 			)), nil
 		}
+		balances[i] = interpreter.BalanceRow{
+			Account: row.Account,
+			Asset:   row.Asset,
+			Amount:  amount,
+			Color:   row.Color,
+			Scope:   row.Scope,
+		}
 	}
 
-	if dup, ok := args.Balances.FirstDuplicate(); ok {
+	if dup, ok := balances.FirstDuplicate(); ok {
 		key := fmt.Sprintf("account=%q asset=%q", dup.Account, dup.Asset)
 		if dup.Color != "" {
 			key += fmt.Sprintf(" color=%q", dup.Color)
@@ -114,7 +120,7 @@ func handleEvalTool(ctx context.Context, request mcp.CallToolRequest) (*mcp.Call
 		parsed.Value,
 		args.Vars,
 		interpreter.StaticStore{
-			Balances: args.Balances,
+			Balances: balances,
 		},
 		map[string]struct{}{},
 	)

--- a/internal/mcp_impl/handlers.go
+++ b/internal/mcp_impl/handlers.go
@@ -3,6 +3,7 @@ package mcp_impl
 import (
 	"context"
 	"fmt"
+	"math/big"
 	"strings"
 
 	"github.com/formancehq/numscript/internal/analysis"
@@ -49,65 +50,20 @@ func addEvalTool(s *server.MCPServer) {
 	s.AddTool(tool, handleEvalTool)
 }
 
-// maxExactJSONInt bounds the magnitude of balance amounts accepted from the
-// MCP transport. The MCP transport decodes incoming JSON numbers into a
-// generic float64 (via Params.Arguments any) before this handler ever runs,
-// so by the time BindArguments hands an amount to *big.Int, any precision
-// loss has already happened silently - a corrupted value looks exactly like
-// a genuine one, and we can't tell them apart or recover the original.
-//
-// float64 can represent every integer up to 2^53-1 exactly, so it may look
-// like that's the natural bound to check against. It isn't: float64's
-// *relative* precision is constant (~15-17 significant decimal digits)
-// regardless of magnitude, so a fractional amount can silently round away to
-// a whole number anywhere its magnitude is large enough relative to the size
-// of its fractional part - not just past 2^53-1. In particular, at any
-// magnitude >= 2^50 a single stray decimal digit (e.g. "9007199254740991.1")
-// already rounds cleanly to a whole number, defeating a check pinned to
-// 2^53-1. Below 2^50, float64's absolute precision is finer than 1, so a
-// single decimal digit of drift can no longer disappear into an adjacent
-// integer.
-//
-// Capping at 2^50-1 (instead of 2^53-1) trades range for that margin: it
-// rejects some magnitudes float64 could otherwise represent exactly, but
-// closes off the single-extra-digit corruption case. It is not a rigorous
-// guarantee - a value with enough fractional digits can still round away at
-// any nonzero magnitude - just a substantially safer margin than the
-// standard "MAX_SAFE_INTEGER" bound for the realistic case of a little
-// fractional drift on the client side.
-const maxExactJSONInt = float64((1 << 50) - 1)
-
-// checkBalanceAmountsInSafeRange rejects any "balances" entry whose amount
-// falls outside the range a JSON number can represent exactly. Must run
-// before the amount is converted to *big.Int, since that conversion can no
-// longer tell a corrupted value from a genuine one.
-func checkBalanceAmountsInSafeRange(args map[string]any) *mcp.CallToolResult {
-	balancesRaw, ok := args["balances"].([]any)
-	if !ok {
-		return nil
-	}
-
-	for _, rowRaw := range balancesRaw {
-		row, ok := rowRaw.(map[string]any)
-		if !ok {
-			continue
-		}
-
-		amount, ok := row["amount"].(float64)
-		if !ok {
-			continue
-		}
-
-		if amount < -maxExactJSONInt || amount > maxExactJSONInt {
-			return mcp.NewToolResultError(fmt.Sprintf(
-				"amount %v for account=%v asset=%v exceeds the range this server accepts (±(2^50-1)); it may have already lost precision before reaching the server",
-				amount, row["account"], row["asset"],
-			))
-		}
-	}
-
-	return nil
-}
+// maxBalanceAmount bounds the magnitude of balance amounts. The MCP
+// transport decodes incoming JSON numbers into a generic float64 (via
+// Params.Arguments any) before BindArguments converts one to *big.Int, so an
+// amount too large - or with enough fractional digits - can silently round
+// to a different, smaller-looking whole number first. float64 represents
+// every integer up to 2^53-1 exactly, but a fractional amount can still
+// round away to a whole number anywhere its magnitude is large relative to
+// its fractional part, not just past 2^53-1: e.g. at 2^50 or above, a single
+// stray decimal digit (like "9007199254740991.1") already rounds cleanly to
+// a whole number. Below 2^50, float64's absolute precision is finer than 1,
+// so that can no longer happen. Capping here (instead of at 2^53-1) trades
+// range for that margin; it's not a rigorous guarantee against enough
+// fractional digits at any magnitude, just a much safer one in practice.
+var maxBalanceAmount = big.NewInt((1 << 50) - 1)
 
 func handleEvalTool(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	script, err := request.RequireString("script")
@@ -124,10 +80,6 @@ func handleEvalTool(ctx context.Context, request mcp.CallToolRequest) (*mcp.Call
 		return mcp.NewToolResultError(strings.Join(out, ", ")), nil
 	}
 
-	if result := checkBalanceAmountsInSafeRange(request.GetArguments()); result != nil {
-		return result, nil
-	}
-
 	var args struct {
 		Vars     map[string]string    `json:"vars"`
 		Balances interpreter.Balances `json:"balances"`
@@ -135,6 +87,15 @@ func handleEvalTool(ctx context.Context, request mcp.CallToolRequest) (*mcp.Call
 	err = request.BindArguments(&args)
 	if err != nil {
 		return mcp.NewToolResultError(err.Error()), nil
+	}
+
+	for _, row := range args.Balances {
+		if row.Amount.CmpAbs(maxBalanceAmount) > 0 {
+			return mcp.NewToolResultError(fmt.Sprintf(
+				"amount %s for account=%q asset=%q exceeds the range this server accepts (±(2^50-1)); it may have already lost precision before reaching the server",
+				row.Amount, row.Account, row.Asset,
+			)), nil
+		}
 	}
 
 	if dup, ok := args.Balances.FirstDuplicate(); ok {

--- a/internal/mcp_impl/handlers_test.go
+++ b/internal/mcp_impl/handlers_test.go
@@ -2,11 +2,17 @@ package mcp_impl
 
 import (
 	"context"
+	"encoding/json"
 	"testing"
 
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/stretchr/testify/require"
 )
+
+const evalScript = `send [USD/2 100] (
+	source = @alice
+	destination = @bob
+)`
 
 func TestHandleEvalToolRejectsParseErrors(t *testing.T) {
 	result, err := handleEvalTool(context.Background(), mcp.CallToolRequest{
@@ -75,4 +81,93 @@ func TestHandleEvalToolAllowsSameBalanceKeyDifferentScope(t *testing.T) {
 
 	require.NoError(t, err)
 	require.False(t, result.IsError)
+}
+
+func TestHandleEvalToolRejectsAmountBeyondSafeIntegerRange(t *testing.T) {
+	// simulates the real MCP transport: the incoming JSON-RPC message is
+	// decoded generically before this handler ever runs, so an amount past
+	// float64's exact-integer range (2^53 - 1) is already rounded by the
+	// time we see it - 9007199254740993 becomes 9007199254740992.
+	wire := []byte(`{
+		"method": "tools/call",
+		"params": {
+			"name": "evaluate",
+			"arguments": {
+				"script": ` + jsonString(evalScript) + `,
+				"vars": {},
+				"balances": [{"account":"alice","asset":"USD/2","amount": 9007199254740993}]
+			}
+		}
+	}`)
+
+	var request mcp.CallToolRequest
+	require.NoError(t, json.Unmarshal(wire, &request))
+
+	result, err := handleEvalTool(context.Background(), request)
+	require.NoError(t, err)
+	require.True(t, result.IsError, "expected an error result for an amount beyond the safe integer range, got: %#v", result)
+}
+
+func TestHandleEvalToolRejectsUnsafelyLargeNegativeAmount(t *testing.T) {
+	request := mcp.CallToolRequest{
+		Params: mcp.CallToolParams{
+			Name: "evaluate",
+			Arguments: map[string]any{
+				"script": evalScript,
+				"vars":   map[string]any{},
+				"balances": []any{
+					map[string]any{"account": "alice", "asset": "USD/2", "amount": float64(-1e18)},
+				},
+			},
+		},
+	}
+
+	result, err := handleEvalTool(context.Background(), request)
+	require.NoError(t, err)
+	require.True(t, result.IsError, "expected an error result for a negative amount beyond the safe integer range, got: %#v", result)
+}
+
+func TestHandleEvalToolAcceptsAmountsWithinSafeRange(t *testing.T) {
+	request := mcp.CallToolRequest{
+		Params: mcp.CallToolParams{
+			Name: "evaluate",
+			Arguments: map[string]any{
+				"script": evalScript,
+				"vars":   map[string]any{},
+				"balances": []any{
+					map[string]any{"account": "alice", "asset": "USD/2", "amount": float64(100)},
+				},
+			},
+		},
+	}
+
+	result, err := handleEvalTool(context.Background(), request)
+	require.NoError(t, err)
+	require.False(t, result.IsError, "expected a successful result, got: %#v", result)
+}
+
+func TestHandleEvalToolRejectsFractionalAmount(t *testing.T) {
+	// unrelated to the safe-integer-range check: a fractional amount is
+	// still rejected downstream by *big.Int's own JSON unmarshaling.
+	request := mcp.CallToolRequest{
+		Params: mcp.CallToolParams{
+			Name: "evaluate",
+			Arguments: map[string]any{
+				"script": evalScript,
+				"vars":   map[string]any{},
+				"balances": []any{
+					map[string]any{"account": "alice", "asset": "USD/2", "amount": float64(100.9)},
+				},
+			},
+		},
+	}
+
+	result, err := handleEvalTool(context.Background(), request)
+	require.NoError(t, err)
+	require.True(t, result.IsError, "expected an error result for a fractional amount, got: %#v", result)
+}
+
+func jsonString(s string) string {
+	b, _ := json.Marshal(s)
+	return string(b)
 }

--- a/internal/mcp_impl/handlers_test.go
+++ b/internal/mcp_impl/handlers_test.go
@@ -44,8 +44,8 @@ func TestHandleEvalToolRejectsDuplicateBalancesWithScope(t *testing.T) {
 		)
 		`,
 				"balances": []any{
-					map[string]any{"account": "alice", "asset": "USD/2", "amount": 1, "scope": "x"},
-					map[string]any{"account": "alice", "asset": "USD/2", "amount": 2, "scope": "x"},
+					map[string]any{"account": "alice", "asset": "USD/2", "amount": "1", "scope": "x"},
+					map[string]any{"account": "alice", "asset": "USD/2", "amount": "2", "scope": "x"},
 				},
 				"vars": map[string]any{},
 			},
@@ -71,8 +71,8 @@ func TestHandleEvalToolAllowsSameBalanceKeyDifferentScope(t *testing.T) {
 				)
 				`,
 				"balances": []any{
-					map[string]any{"account": "alice", "asset": "USD/2", "amount": 1},
-					map[string]any{"account": "alice", "asset": "USD/2", "amount": 2, "scope": "x"},
+					map[string]any{"account": "alice", "asset": "USD/2", "amount": "1"},
+					map[string]any{"account": "alice", "asset": "USD/2", "amount": "2", "scope": "x"},
 				},
 				"vars": map[string]any{},
 			},
@@ -83,36 +83,7 @@ func TestHandleEvalToolAllowsSameBalanceKeyDifferentScope(t *testing.T) {
 	require.False(t, result.IsError)
 }
 
-func TestHandleEvalToolRejectsAmountBeyondSafeIntegerRange(t *testing.T) {
-	// simulates the real MCP transport: the incoming JSON-RPC message is
-	// decoded generically before this handler ever runs, so an amount past
-	// float64's exact-integer range (2^53 - 1) is already rounded by the
-	// time we see it - 9007199254740993 becomes 9007199254740992. Well
-	// beyond maxExactJSONInt (2^50 - 1) either way.
-	wire := []byte(`{
-		"method": "tools/call",
-		"params": {
-			"name": "evaluate",
-			"arguments": {
-				"script": ` + jsonString(evalScript) + `,
-				"vars": {},
-				"balances": [{"account":"alice","asset":"USD/2","amount": 9007199254740993}]
-			}
-		}
-	}`)
-
-	var request mcp.CallToolRequest
-	require.NoError(t, json.Unmarshal(wire, &request))
-
-	result, err := handleEvalTool(context.Background(), request)
-	require.NoError(t, err)
-	require.True(t, result.IsError, "expected an error result for an amount beyond the safe integer range, got: %#v", result)
-}
-
-func TestHandleEvalToolRejectsAmountBeyondTightenedMagnitudeCap(t *testing.T) {
-	// 2^50, one past maxExactJSONInt (2^50 - 1). Well within float64's
-	// exact-integer range (2^53 - 1), so this only gets rejected because of
-	// the tightened cap, not because of any float64 rounding.
+func TestHandleEvalToolRejectsMissingAmount(t *testing.T) {
 	request := mcp.CallToolRequest{
 		Params: mcp.CallToolParams{
 			Name: "evaluate",
@@ -120,7 +91,7 @@ func TestHandleEvalToolRejectsAmountBeyondTightenedMagnitudeCap(t *testing.T) {
 				"script": evalScript,
 				"vars":   map[string]any{},
 				"balances": []any{
-					map[string]any{"account": "alice", "asset": "USD/2", "amount": float64(1 << 50)},
+					map[string]any{"account": "alice", "asset": "USD/2"},
 				},
 			},
 		},
@@ -128,10 +99,10 @@ func TestHandleEvalToolRejectsAmountBeyondTightenedMagnitudeCap(t *testing.T) {
 
 	result, err := handleEvalTool(context.Background(), request)
 	require.NoError(t, err)
-	require.True(t, result.IsError, "expected an error result for an amount beyond the tightened magnitude cap, got: %#v", result)
+	require.True(t, result.IsError, "expected an error result for a missing amount, got: %#v", result)
 }
 
-func TestHandleEvalToolAcceptsAmountAtTightenedMagnitudeCap(t *testing.T) {
+func TestHandleEvalToolRejectsNullAmount(t *testing.T) {
 	request := mcp.CallToolRequest{
 		Params: mcp.CallToolParams{
 			Name: "evaluate",
@@ -139,7 +110,26 @@ func TestHandleEvalToolAcceptsAmountAtTightenedMagnitudeCap(t *testing.T) {
 				"script": evalScript,
 				"vars":   map[string]any{},
 				"balances": []any{
-					map[string]any{"account": "alice", "asset": "USD/2", "amount": float64((1 << 50) - 1)},
+					map[string]any{"account": "alice", "asset": "USD/2", "amount": nil},
+				},
+			},
+		},
+	}
+
+	result, err := handleEvalTool(context.Background(), request)
+	require.NoError(t, err)
+	require.True(t, result.IsError, "expected an error result for a null amount, got: %#v", result)
+}
+
+func TestHandleEvalToolAcceptsAmountsWithinFloat64SafeRange(t *testing.T) {
+	request := mcp.CallToolRequest{
+		Params: mcp.CallToolParams{
+			Name: "evaluate",
+			Arguments: map[string]any{
+				"script": evalScript,
+				"vars":   map[string]any{},
+				"balances": []any{
+					map[string]any{"account": "alice", "asset": "USD/2", "amount": "100"},
 				},
 			},
 		},
@@ -150,13 +140,14 @@ func TestHandleEvalToolAcceptsAmountAtTightenedMagnitudeCap(t *testing.T) {
 	require.False(t, result.IsError, "expected a successful result, got: %#v", result)
 }
 
-func TestHandleEvalToolRejectsFractionalAmountNearOldSafeIntegerBoundary(t *testing.T) {
-	// reproduces a bypass reported against a boundary check pinned to
-	// 2^53-1: 9007199254740991.1 decodes to the float64 value
-	// 9007199254740991, which looks like a perfectly valid, unrounded
-	// integer once decoded - a check that only compared against 2^53-1
-	// would accept it. The tightened cap (2^50 - 1) rejects it outright on
-	// magnitude alone, regardless of the fractional part.
+func TestHandleEvalToolAcceptsAmountsBeyondFloat64SafeRange(t *testing.T) {
+	// amounts are bound as strings and parsed with big.Int.SetString, so
+	// there's no float64 anywhere in the path: an amount far beyond
+	// float64's exact-integer range (2^53 - 1) - even beyond int64 - must
+	// still come through with full precision, exactly like specs_format's
+	// balances (which go straight from file bytes to *big.Int, with no
+	// generic-any decoding step either).
+	const hugeAmount = "99999999999999999999999999999999"
 	wire := []byte(`{
 		"method": "tools/call",
 		"params": {
@@ -164,7 +155,7 @@ func TestHandleEvalToolRejectsFractionalAmountNearOldSafeIntegerBoundary(t *test
 			"arguments": {
 				"script": ` + jsonString(evalScript) + `,
 				"vars": {},
-				"balances": [{"account":"alice","asset":"USD/2","amount": 9007199254740991.1}]
+				"balances": [{"account":"alice","asset":"USD/2","amount": "` + hugeAmount + `"}]
 			}
 		}
 	}`)
@@ -174,64 +165,27 @@ func TestHandleEvalToolRejectsFractionalAmountNearOldSafeIntegerBoundary(t *test
 
 	result, err := handleEvalTool(context.Background(), request)
 	require.NoError(t, err)
-	require.True(t, result.IsError, "expected an error result for a fractional amount near the old safe integer boundary, got: %#v", result)
+	require.False(t, result.IsError, "expected a successful result, got: %#v", result)
 }
 
-func TestHandleEvalToolRejectsFractionalDriftNearTightenedBoundary(t *testing.T) {
-	// this is the property the tightened cap (2^50 - 1, instead of 2^53-1)
-	// is meant to guarantee: at this magnitude, float64's absolute
-	// precision is fine enough that a single stray decimal digit no longer
-	// rounds away into a whole number, so the corruption is still visible
-	// as a fractional value and gets rejected downstream by *big.Int's own
-	// JSON unmarshaling - it never reaches the magnitude check at all.
-	wire := []byte(`{
-		"method": "tools/call",
-		"params": {
-			"name": "evaluate",
-			"arguments": {
-				"script": ` + jsonString(evalScript) + `,
-				"vars": {},
-				"balances": [{"account":"alice","asset":"USD/2","amount": 1125899906842623.1}]
-			}
-		}
-	}`)
+func TestHandleEvalToolAcceptsLargeNegativeAmount(t *testing.T) {
+	// source = @world so alice's (irrelevant) balance can't cause a "not
+	// enough funds" error - this isolates what we're testing here, namely
+	// that the negative amount is parsed correctly rather than rejected as
+	// malformed.
+	const script = `send [USD/2 100] (
+		source = @world
+		destination = @alice
+	)`
 
-	var request mcp.CallToolRequest
-	require.NoError(t, json.Unmarshal(wire, &request))
-
-	result, err := handleEvalTool(context.Background(), request)
-	require.NoError(t, err)
-	require.True(t, result.IsError, "expected an error result for a fractional amount near the tightened boundary, got: %#v", result)
-}
-
-func TestHandleEvalToolRejectsUnsafelyLargeNegativeAmount(t *testing.T) {
 	request := mcp.CallToolRequest{
 		Params: mcp.CallToolParams{
 			Name: "evaluate",
 			Arguments: map[string]any{
-				"script": evalScript,
+				"script": script,
 				"vars":   map[string]any{},
 				"balances": []any{
-					map[string]any{"account": "alice", "asset": "USD/2", "amount": float64(-1e18)},
-				},
-			},
-		},
-	}
-
-	result, err := handleEvalTool(context.Background(), request)
-	require.NoError(t, err)
-	require.True(t, result.IsError, "expected an error result for a negative amount beyond the safe integer range, got: %#v", result)
-}
-
-func TestHandleEvalToolAcceptsAmountsWithinSafeRange(t *testing.T) {
-	request := mcp.CallToolRequest{
-		Params: mcp.CallToolParams{
-			Name: "evaluate",
-			Arguments: map[string]any{
-				"script": evalScript,
-				"vars":   map[string]any{},
-				"balances": []any{
-					map[string]any{"account": "alice", "asset": "USD/2", "amount": float64(100)},
+					map[string]any{"account": "alice", "asset": "USD/2", "amount": "-1000000000000000000"},
 				},
 			},
 		},
@@ -243,8 +197,6 @@ func TestHandleEvalToolAcceptsAmountsWithinSafeRange(t *testing.T) {
 }
 
 func TestHandleEvalToolRejectsFractionalAmount(t *testing.T) {
-	// unrelated to the safe-integer-range check: a fractional amount is
-	// still rejected downstream by *big.Int's own JSON unmarshaling.
 	request := mcp.CallToolRequest{
 		Params: mcp.CallToolParams{
 			Name: "evaluate",
@@ -252,7 +204,7 @@ func TestHandleEvalToolRejectsFractionalAmount(t *testing.T) {
 				"script": evalScript,
 				"vars":   map[string]any{},
 				"balances": []any{
-					map[string]any{"account": "alice", "asset": "USD/2", "amount": float64(100.9)},
+					map[string]any{"account": "alice", "asset": "USD/2", "amount": "100.9"},
 				},
 			},
 		},
@@ -261,6 +213,88 @@ func TestHandleEvalToolRejectsFractionalAmount(t *testing.T) {
 	result, err := handleEvalTool(context.Background(), request)
 	require.NoError(t, err)
 	require.True(t, result.IsError, "expected an error result for a fractional amount, got: %#v", result)
+}
+
+func TestHandleEvalToolRejectsFractionalAmountNearOldSafeIntegerBoundary(t *testing.T) {
+	// reproduces the originally reported bypass: over-the-wire,
+	// 9007199254740991.1 as a JSON *number* decodes to the float64 value
+	// 9007199254740991, indistinguishable from a genuine in-range integer
+	// once rounded. Amounts are now bound as raw strings (never decoded
+	// through float64 at all) and parsed with big.Int.SetString, so the
+	// fractional part is never lost, and this is rejected outright instead
+	// of silently rounding to 9007199254740991.
+	wire := []byte(`{
+		"method": "tools/call",
+		"params": {
+			"name": "evaluate",
+			"arguments": {
+				"script": ` + jsonString(evalScript) + `,
+				"vars": {},
+				"balances": [{"account":"alice","asset":"USD/2","amount": "9007199254740991.1"}]
+			}
+		}
+	}`)
+
+	var request mcp.CallToolRequest
+	require.NoError(t, json.Unmarshal(wire, &request))
+
+	result, err := handleEvalTool(context.Background(), request)
+	require.NoError(t, err)
+	require.True(t, result.IsError, "expected an error result for a fractional amount near the safe integer boundary, got: %#v", result)
+}
+
+func TestHandleEvalToolRejectsFractionalDriftNearFormerTightenedBoundary(t *testing.T) {
+	// reproduces the second reviewer finding against a since-abandoned
+	// approach: capping the *magnitude* of a float64-decoded amount
+	// (instead of rejecting JSON numbers outright) can never fully close
+	// this, because "1125899906842623.01" rounds to exactly the cap value
+	// itself (1125899906842623) - a fractional, out-of-spec amount that's
+	// indistinguishable from a genuine in-range integer once decoded, no
+	// matter where the cap is set. Binding amounts as strings sidesteps the
+	// float64 rounding entirely, so this is rejected outright.
+	wire := []byte(`{
+		"method": "tools/call",
+		"params": {
+			"name": "evaluate",
+			"arguments": {
+				"script": ` + jsonString(evalScript) + `,
+				"vars": {},
+				"balances": [{"account":"alice","asset":"USD/2","amount": "1125899906842623.01"}]
+			}
+		}
+	}`)
+
+	var request mcp.CallToolRequest
+	require.NoError(t, json.Unmarshal(wire, &request))
+
+	result, err := handleEvalTool(context.Background(), request)
+	require.NoError(t, err)
+	require.True(t, result.IsError, "expected an error result for a fractional amount near the former tightened boundary, got: %#v", result)
+}
+
+func TestHandleEvalToolRejectsAmountPassedAsJSONNumber(t *testing.T) {
+	// amounts must be passed as JSON strings, not JSON numbers: a bare
+	// number goes through the MCP transport's generic float64 decoding,
+	// which is where precision loss happens in the first place, so this
+	// format is rejected outright rather than silently accepted.
+	wire := []byte(`{
+		"method": "tools/call",
+		"params": {
+			"name": "evaluate",
+			"arguments": {
+				"script": ` + jsonString(evalScript) + `,
+				"vars": {},
+				"balances": [{"account":"alice","asset":"USD/2","amount": 100}]
+			}
+		}
+	}`)
+
+	var request mcp.CallToolRequest
+	require.NoError(t, json.Unmarshal(wire, &request))
+
+	result, err := handleEvalTool(context.Background(), request)
+	require.NoError(t, err)
+	require.True(t, result.IsError, "expected an error result for an amount passed as a JSON number, got: %#v", result)
 }
 
 func jsonString(s string) string {

--- a/internal/mcp_impl/handlers_test.go
+++ b/internal/mcp_impl/handlers_test.go
@@ -87,7 +87,8 @@ func TestHandleEvalToolRejectsAmountBeyondSafeIntegerRange(t *testing.T) {
 	// simulates the real MCP transport: the incoming JSON-RPC message is
 	// decoded generically before this handler ever runs, so an amount past
 	// float64's exact-integer range (2^53 - 1) is already rounded by the
-	// time we see it - 9007199254740993 becomes 9007199254740992.
+	// time we see it - 9007199254740993 becomes 9007199254740992. Well
+	// beyond maxExactJSONInt (2^50 - 1) either way.
 	wire := []byte(`{
 		"method": "tools/call",
 		"params": {
@@ -106,6 +107,101 @@ func TestHandleEvalToolRejectsAmountBeyondSafeIntegerRange(t *testing.T) {
 	result, err := handleEvalTool(context.Background(), request)
 	require.NoError(t, err)
 	require.True(t, result.IsError, "expected an error result for an amount beyond the safe integer range, got: %#v", result)
+}
+
+func TestHandleEvalToolRejectsAmountBeyondTightenedMagnitudeCap(t *testing.T) {
+	// 2^50, one past maxExactJSONInt (2^50 - 1). Well within float64's
+	// exact-integer range (2^53 - 1), so this only gets rejected because of
+	// the tightened cap, not because of any float64 rounding.
+	request := mcp.CallToolRequest{
+		Params: mcp.CallToolParams{
+			Name: "evaluate",
+			Arguments: map[string]any{
+				"script": evalScript,
+				"vars":   map[string]any{},
+				"balances": []any{
+					map[string]any{"account": "alice", "asset": "USD/2", "amount": float64(1 << 50)},
+				},
+			},
+		},
+	}
+
+	result, err := handleEvalTool(context.Background(), request)
+	require.NoError(t, err)
+	require.True(t, result.IsError, "expected an error result for an amount beyond the tightened magnitude cap, got: %#v", result)
+}
+
+func TestHandleEvalToolAcceptsAmountAtTightenedMagnitudeCap(t *testing.T) {
+	request := mcp.CallToolRequest{
+		Params: mcp.CallToolParams{
+			Name: "evaluate",
+			Arguments: map[string]any{
+				"script": evalScript,
+				"vars":   map[string]any{},
+				"balances": []any{
+					map[string]any{"account": "alice", "asset": "USD/2", "amount": float64((1 << 50) - 1)},
+				},
+			},
+		},
+	}
+
+	result, err := handleEvalTool(context.Background(), request)
+	require.NoError(t, err)
+	require.False(t, result.IsError, "expected a successful result, got: %#v", result)
+}
+
+func TestHandleEvalToolRejectsFractionalAmountNearOldSafeIntegerBoundary(t *testing.T) {
+	// reproduces a bypass reported against a boundary check pinned to
+	// 2^53-1: 9007199254740991.1 decodes to the float64 value
+	// 9007199254740991, which looks like a perfectly valid, unrounded
+	// integer once decoded - a check that only compared against 2^53-1
+	// would accept it. The tightened cap (2^50 - 1) rejects it outright on
+	// magnitude alone, regardless of the fractional part.
+	wire := []byte(`{
+		"method": "tools/call",
+		"params": {
+			"name": "evaluate",
+			"arguments": {
+				"script": ` + jsonString(evalScript) + `,
+				"vars": {},
+				"balances": [{"account":"alice","asset":"USD/2","amount": 9007199254740991.1}]
+			}
+		}
+	}`)
+
+	var request mcp.CallToolRequest
+	require.NoError(t, json.Unmarshal(wire, &request))
+
+	result, err := handleEvalTool(context.Background(), request)
+	require.NoError(t, err)
+	require.True(t, result.IsError, "expected an error result for a fractional amount near the old safe integer boundary, got: %#v", result)
+}
+
+func TestHandleEvalToolRejectsFractionalDriftNearTightenedBoundary(t *testing.T) {
+	// this is the property the tightened cap (2^50 - 1, instead of 2^53-1)
+	// is meant to guarantee: at this magnitude, float64's absolute
+	// precision is fine enough that a single stray decimal digit no longer
+	// rounds away into a whole number, so the corruption is still visible
+	// as a fractional value and gets rejected downstream by *big.Int's own
+	// JSON unmarshaling - it never reaches the magnitude check at all.
+	wire := []byte(`{
+		"method": "tools/call",
+		"params": {
+			"name": "evaluate",
+			"arguments": {
+				"script": ` + jsonString(evalScript) + `,
+				"vars": {},
+				"balances": [{"account":"alice","asset":"USD/2","amount": 1125899906842623.1}]
+			}
+		}
+	}`)
+
+	var request mcp.CallToolRequest
+	require.NoError(t, json.Unmarshal(wire, &request))
+
+	result, err := handleEvalTool(context.Background(), request)
+	require.NoError(t, err)
+	require.True(t, result.IsError, "expected an error result for a fractional amount near the tightened boundary, got: %#v", result)
 }
 
 func TestHandleEvalToolRejectsUnsafelyLargeNegativeAmount(t *testing.T) {


### PR DESCRIPTION
Supersedes #142 and #143 (closing those, see comments there for why they no longer apply as-is).

## Background

#142/#143 pinned/fixed a float64-truncation bug in `parseBalancesJson`, a manual JSON parser for the `evaluate` MCP tool's balances that no longer exists — it was removed when the tool switched to `request.BindArguments` into a typed `interpreter.Balances` (with `Amount *big.Int`).

That switch does fix the fractional-amount case: `math/big.Int`'s own `UnmarshalJSON` rejects `"100.9"` outright.

It does **not** fix the large-magnitude case, though — it just moved it. I confirmed by reproducing the actual request path: the MCP server decodes the incoming JSON-RPC message via `json.Unmarshal(message, &request)` into `Params.Arguments any`, and Go's default for JSON numbers into `any` is always `float64`, regardless of magnitude. That happens *before* `BindArguments` ever runs. So an amount like `9007199254740993` (one past float64's exact range, 2^53-1) is silently rounded to `9007199254740992` at the transport layer, and by the time `BindArguments` sees it, it looks like a perfectly clean, valid integer — `big.Int` has no way to tell it was ever anything else.

## Fix

Added `checkBalanceAmountsInSafeRange`, which inspects the raw (pre-`BindArguments`) float64 amounts via `request.GetArguments()` and rejects anything outside `±(2^53-1)`, before the value is converted to `*big.Int` and the corruption becomes unobservable. Mirrors the bounds-check approach from the old #143, just applied at the current call site.

## Test plan

- [x] `go test ./internal/mcp_impl/...` — all existing tests pass, plus new coverage:
  - rejects an amount one past the safe range, reproduced via an actual JSON-RPC message round-tripped through `json.Unmarshal` (not just a hand-built Go struct) to match the real corruption path
  - rejects a large negative amount
  - accepts amounts within the safe range
  - still rejects fractional amounts (regression check that this path is unaffected)