### PR TITLE
fix(cmd): propagate specs file write errors in test-init

### DIFF
--- a/internal/cmd/test_init.go
+++ b/internal/cmd/test_init.go
@@ -192,7 +192,9 @@ func runTestInitCmd(opts testInitArgs) error {
 
 	marshaled, _ := json.MarshalIndent(specs, "", "  ")
 
-	_ = os.WriteFile(opts.path+".specs.json", marshaled, 0644)
+	if err := os.WriteFile(opts.path+".specs.json", marshaled, 0644); err != nil {
+		return fmt.Errorf("failed to write specs file: %w", err)
+	}
 
 	fmt.Printf("✅ Created specs file: %s.specs.json\n", opts.path)
 

--- a/internal/cmd/test_init_internal_test.go
+++ b/internal/cmd/test_init_internal_test.go
@@ -1,0 +1,30 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+const testInitNumscript = `send [USD/2 100] (
+	source = @world
+	destination = @bob
+)
+`
+
+func TestRunTestInitCmdPropagatesWriteError(t *testing.T) {
+	dir := t.TempDir()
+	scriptPath := filepath.Join(dir, "main.num")
+	require.NoError(t, os.WriteFile(scriptPath, []byte(testInitNumscript), 0644))
+
+	// create a directory where the specs file should be written, so that
+	// os.WriteFile fails deterministically
+	require.NoError(t, os.Mkdir(scriptPath+".specs.json", 0755))
+
+	err := runTestInitCmd(testInitArgs{path: scriptPath})
+
+	require.Error(t, err)
+	require.ErrorContains(t, err, "failed to write specs file")
+}


### PR DESCRIPTION
Follow-up to #148 (which you closed) — recreating just the reachable half of that fix.

## Background

#148 bundled two fixes: propagating `os.WriteFile`'s error, and propagating `json.MarshalIndent`'s error (via an injectable `jsonMarshalIndent` var so a test could force a failure). We determined the marshal-error path is unreachable in practice — every field in `specs_format.Specs` is a string, bool, or `*big.Int`, none of which `encoding/json.Marshal` can fail on (no floats, no cycles, no unsupported types, and `*big.Int.MarshalJSON` always succeeds) — so that half was dropped.

The `os.WriteFile` half is a real, reachable bug on `main` today: its error is discarded (`_ = os.WriteFile(...)`), so `test-init` prints `✅ Created specs file` and exits 0 even when nothing was written (disk full, permission denied, target path already exists as a directory, etc.).

## Fix

Propagate `os.WriteFile`'s error instead of discarding it. Left `json.MarshalIndent`'s error un-propagated and inline (no injection seam) — consistent with the rest of the codebase's convention of discarding errors from calls that can't realistically fail (see the `_, _ = ...` writes throughout `specs_format/runner.go`).

## Test plan

- [x] `go test ./internal/cmd/...` — new test creates a directory at the target `.specs.json` path so the write deterministically fails, and asserts the error propagates with a clear message