### PR TITLE
feat: expose migration tool

### DIFF
--- a/internal/cmd/e2e_test.go
+++ b/internal/cmd/e2e_test.go
@@ -1,0 +1,98 @@
+package cmd_test
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// e2eBinaryPath is the real numscript binary, built once in TestMain. Unlike
+// the rest of this package's tests, which call cmd/specs_format functions
+// in-process, these tests exec the actual CLI: runTestCmd calls os.Exit
+// directly, so it can only be observed as a subprocess, and this is also the
+// only place that exercises cobra's flag wiring (e.g. --migrate) end to end.
+var e2eBinaryPath string
+
+func TestMain(m *testing.M) {
+	dir, err := os.MkdirTemp("", "numscript-e2e-")
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer os.RemoveAll(dir)
+
+	e2eBinaryPath = filepath.Join(dir, "numscript")
+	buildCmd := exec.Command("go", "build", "-o", e2eBinaryPath, "github.com/formancehq/numscript/cmd/numscript")
+	if out, err := buildCmd.CombinedOutput(); err != nil {
+		fmt.Fprintf(os.Stderr, "failed to build numscript binary: %s\n%s\n", err, out)
+		os.Exit(1)
+	}
+
+	os.Exit(m.Run())
+}
+
+const e2eNumscript = `send [USD/2 100] (
+	source = @world
+	destination = @dest
+)
+set_account_meta(@dest, "k", [USD/2 100])
+`
+
+// e2eSpecsMissingSchema deliberately has no $schema: that's the only thing
+// --migrate fixes, and it should not affect whether the tests pass either
+// way.
+const e2eSpecsMissingSchema = `{
+	"testCases": [
+		{
+			"it": "-",
+			"expect.metadata": [
+				{ "account": "dest", "key": "k", "value": "USD/2 100" }
+			],
+			"expect.postings": null
+		}
+	]
+}
+`
+
+func writeE2ESpecsFixture(t *testing.T) (dir string, specsPath string) {
+	dir = t.TempDir()
+	numscriptPath := filepath.Join(dir, "main.num")
+	specsPath = numscriptPath + ".specs.json"
+
+	require.NoError(t, os.WriteFile(numscriptPath, []byte(e2eNumscript), 0644))
+	require.NoError(t, os.WriteFile(specsPath, []byte(e2eSpecsMissingSchema), 0644))
+
+	return dir, specsPath
+}
+
+func TestE2ETestPassesWithoutSchema(t *testing.T) {
+	dir, _ := writeE2ESpecsFixture(t)
+
+	cmd := exec.Command(e2eBinaryPath, "test", dir)
+	out, err := cmd.CombinedOutput()
+	require.NoError(t, err, string(out))
+}
+
+func TestE2ETestMigrateAddsSchema(t *testing.T) {
+	dir, specsPath := writeE2ESpecsFixture(t)
+
+	cmd := exec.Command(e2eBinaryPath, "test", "--migrate", dir)
+	out, err := cmd.CombinedOutput()
+	require.NoError(t, err, string(out))
+	require.Contains(t, string(out), "migrated")
+
+	migrated, err := os.ReadFile(specsPath)
+	require.NoError(t, err)
+	require.Contains(t, string(migrated), `"$schema"`)
+	require.Contains(t, string(migrated), `"value": "USD/2 100"`)
+
+	// running again against the now-migrated file passes cleanly, with no
+	// further migration needed.
+	rerun := exec.Command(e2eBinaryPath, "test", dir)
+	rerunOut, err := rerun.CombinedOutput()
+	require.NoError(t, err, string(rerunOut))
+}

--- a/internal/cmd/e2e_test.go
+++ b/internal/cmd/e2e_test.go
@@ -23,16 +23,20 @@ func TestMain(m *testing.M) {
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}
-	defer os.RemoveAll(dir)
 
 	e2eBinaryPath = filepath.Join(dir, "numscript")
 	buildCmd := exec.Command("go", "build", "-o", e2eBinaryPath, "github.com/formancehq/numscript/cmd/numscript")
 	if out, err := buildCmd.CombinedOutput(); err != nil {
 		fmt.Fprintf(os.Stderr, "failed to build numscript binary: %s\n%s\n", err, out)
+		_ = os.RemoveAll(dir)
 		os.Exit(1)
 	}
 
-	os.Exit(m.Run())
+	// os.Exit below bypasses defers, so clean up explicitly beforehand rather
+	// than deferring it.
+	code := m.Run()
+	_ = os.RemoveAll(dir)
+	os.Exit(code)
 }
 
 const e2eNumscript = `send [USD/2 100] (

--- a/internal/cmd/e2e_test.go
+++ b/internal/cmd/e2e_test.go
@@ -48,7 +48,7 @@ set_account_meta(@dest, "k", [USD/2 100])
 
 // e2eSpecsMissingSchema deliberately has no $schema: that's the only thing
 // --migrate fixes, and it should not affect whether the tests pass either
-// way.
+// way ($schema is an editor hint, not part of the format).
 const e2eSpecsMissingSchema = `{
 	"testCases": [
 		{
@@ -96,6 +96,80 @@ func TestE2ETestMigrateAddsSchema(t *testing.T) {
 
 	// running again against the now-migrated file passes cleanly, with no
 	// further migration needed.
+	rerun := exec.Command(e2eBinaryPath, "test", dir)
+	rerunOut, err := rerun.CombinedOutput()
+	require.NoError(t, err, string(rerunOut))
+}
+
+// e2eLegacyV0024Numscript and e2eLegacyV0024Specs are the exact script and
+// specs file v0.0.24 (commit 1b42b98, the last tagged release) generated:
+// balances/metadata as nested maps rather than today's row arrays.
+const e2eLegacyV0024Numscript = `vars {
+	account $sale
+	account $seller = meta($sale, "seller")
+	portion $commission = meta($seller, "commission")
+}
+send [EUR/2 100] (
+	source = $sale
+	destination = {
+		remaining to $seller
+		$commission to @platform
+	}
+)
+`
+
+const e2eLegacyV0024Specs = `{
+	"testCases": [
+		{
+			"it": "-",
+			"balances": {
+				"sales:042": { "EUR/2": 2500 },
+				"users:053": { "EUR/2": 500 }
+			},
+			"variables": { "sale": "sales:042" },
+			"metadata": {
+				"sales:042": { "seller": "users:053" },
+				"users:053": { "commission": "12.5%" }
+			},
+			"expect.postings": [
+				{ "source": "sales:042", "destination": "users:053", "amount": 88, "asset": "EUR/2" },
+				{ "source": "sales:042", "destination": "platform", "amount": 12, "asset": "EUR/2" }
+			]
+		}
+	]
+}
+`
+
+func TestE2ETestRejectsLegacyV0024Shape(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "main.num"), []byte(e2eLegacyV0024Numscript), 0644))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "main.num.specs.json"), []byte(e2eLegacyV0024Specs), 0644))
+
+	cmd := exec.Command(e2eBinaryPath, "test", dir)
+	out, err := cmd.CombinedOutput()
+
+	var exitErr *exec.ExitError
+	require.ErrorAs(t, err, &exitErr)
+	require.Equal(t, 1, exitErr.ExitCode())
+	require.Contains(t, string(out), "cannot unmarshal object")
+}
+
+func TestE2ETestMigrateConvertsLegacyV0024Shape(t *testing.T) {
+	dir := t.TempDir()
+	specsPath := filepath.Join(dir, "main.num.specs.json")
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "main.num"), []byte(e2eLegacyV0024Numscript), 0644))
+	require.NoError(t, os.WriteFile(specsPath, []byte(e2eLegacyV0024Specs), 0644))
+
+	cmd := exec.Command(e2eBinaryPath, "test", "--migrate", dir)
+	out, err := cmd.CombinedOutput()
+	require.NoError(t, err, string(out))
+	require.Contains(t, string(out), "migrated")
+
+	migrated, err := os.ReadFile(specsPath)
+	require.NoError(t, err)
+	require.Contains(t, string(migrated), `"account": "sales:042"`)
+	require.Contains(t, string(migrated), `"asset": "EUR/2"`)
+
 	rerun := exec.Command(e2eBinaryPath, "test", dir)
 	rerunOut, err := rerun.CombinedOutput()
 	require.NoError(t, err, string(rerunOut))

--- a/internal/cmd/e2e_test.go
+++ b/internal/cmd/e2e_test.go
@@ -171,3 +171,57 @@ func TestE2ETestMigrateConvertsLegacyV0024Shape(t *testing.T) {
 	rerunOut, err := rerun.CombinedOutput()
 	require.NoError(t, err, string(rerunOut))
 }
+
+// e2eLegacyColorNumscript and e2eLegacyColorSpecs are the exact script and
+// specs file v0.0.24 generated for a colored send (its
+// asset-colors/color-with-asset-precision fixture). The specs file is
+// structurally current — its only outdated part is the ASSET_COLOR encoding in
+// expect.postings, so it is the case a structural check alone cannot catch.
+const e2eLegacyColorNumscript = `send [USD/4 10] (
+	source = @src \ "COL" allowing unbounded overdraft
+	destination = @dest
+)
+`
+
+const e2eLegacyColorSpecs = `{
+	"featureFlags": [
+		"experimental-asset-colors"
+	],
+	"testCases": [
+		{
+			"it": "-",
+			"expect.postings": [
+				{ "source": "src", "destination": "dest", "amount": 10, "asset": "USD_COL/4" }
+			]
+		}
+	]
+}
+`
+
+func TestE2ETestMigrateDecodesLegacyColors(t *testing.T) {
+	dir := t.TempDir()
+	specsPath := filepath.Join(dir, "main.num.specs.json")
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "main.num"), []byte(e2eLegacyColorNumscript), 0644))
+	require.NoError(t, os.WriteFile(specsPath, []byte(e2eLegacyColorSpecs), 0644))
+
+	// Before migrating, the encoded asset makes the expectation fail: the
+	// interpreter reports asset USD/4 with color COL.
+	before := exec.Command(e2eBinaryPath, "test", dir)
+	beforeOut, err := before.CombinedOutput()
+	require.Error(t, err, string(beforeOut))
+
+	cmd := exec.Command(e2eBinaryPath, "test", "--migrate", dir)
+	out, err := cmd.CombinedOutput()
+	require.NoError(t, err, string(out))
+	require.Contains(t, string(out), "migrated")
+
+	migrated, err := os.ReadFile(specsPath)
+	require.NoError(t, err)
+	require.Contains(t, string(migrated), `"asset": "USD/4"`)
+	require.Contains(t, string(migrated), `"color": "COL"`)
+	require.NotContains(t, string(migrated), "USD_COL")
+
+	rerun := exec.Command(e2eBinaryPath, "test", dir)
+	rerunOut, err := rerun.CombinedOutput()
+	require.NoError(t, err, string(rerunOut))
+}

--- a/internal/cmd/e2e_test.go
+++ b/internal/cmd/e2e_test.go
@@ -46,9 +46,9 @@ const e2eNumscript = `send [USD/2 100] (
 set_account_meta(@dest, "k", [USD/2 100])
 `
 
-// e2eSpecsMissingSchema deliberately has no $schema: that's the only thing
-// --migrate fixes, and it should not affect whether the tests pass either
-// way ($schema is an editor hint, not part of the format).
+// e2eSpecsMissingSchema deliberately has no $schema: it's an editor hint, not
+// part of the format, so it affects neither whether the tests pass nor whether
+// --migrate considers the file stale.
 const e2eSpecsMissingSchema = `{
 	"testCases": [
 		{
@@ -81,24 +81,21 @@ func TestE2ETestPassesWithoutSchema(t *testing.T) {
 	require.NoError(t, err, string(out))
 }
 
-func TestE2ETestMigrateAddsSchema(t *testing.T) {
+// --migrate only rewrites files whose structure is outdated. A current-shape
+// file is left byte-for-byte alone, even with no $schema to point at the
+// current schema: reformatting a file to insert an editor hint isn't a
+// migration.
+func TestE2ETestMigrateLeavesCurrentShapeAlone(t *testing.T) {
 	dir, specsPath := writeE2ESpecsFixture(t)
 
 	cmd := exec.Command(e2eBinaryPath, "test", "--migrate", dir)
 	out, err := cmd.CombinedOutput()
 	require.NoError(t, err, string(out))
-	require.Contains(t, string(out), "migrated")
+	require.NotContains(t, string(out), "migrated")
 
-	migrated, err := os.ReadFile(specsPath)
+	after, err := os.ReadFile(specsPath)
 	require.NoError(t, err)
-	require.Contains(t, string(migrated), `"$schema"`)
-	require.Contains(t, string(migrated), `"value": "USD/2 100"`)
-
-	// running again against the now-migrated file passes cleanly, with no
-	// further migration needed.
-	rerun := exec.Command(e2eBinaryPath, "test", dir)
-	rerunOut, err := rerun.CombinedOutput()
-	require.NoError(t, err, string(rerunOut))
+	require.Equal(t, e2eSpecsMissingSchema, string(after))
 }
 
 // e2eLegacyV0024Numscript and e2eLegacyV0024Specs are the exact script and

--- a/internal/cmd/test.go
+++ b/internal/cmd/test.go
@@ -1,14 +1,17 @@
 package cmd
 
 import (
+	"fmt"
 	"os"
 
+	"github.com/formancehq/numscript/internal/ansi"
 	"github.com/formancehq/numscript/internal/specs_format"
 	"github.com/spf13/cobra"
 )
 
 type testArgs struct {
-	paths []string
+	paths   []string
+	migrate bool
 }
 
 func runTestCmd(opts testArgs) {
@@ -19,13 +22,44 @@ func runTestCmd(opts testArgs) {
 		return
 	}
 
+	if opts.migrate {
+		migrateSpecsFiles(files)
+	}
+
 	pass := specs_format.RunSpecs(os.Stdout, os.Stderr, files)
 	if !pass {
 		os.Exit(1)
 	}
 }
 
+// migrateSpecsFiles rewrites any stale specs file to the current format in
+// place.
+//
+// It also updates each migrated file's in-memory content, so the RunSpecs
+// call right after sees the already-current version instead of re-reading
+// the pre-migration bytes.
+func migrateSpecsFiles(files []specs_format.RawSpec) {
+	for i, file := range files {
+		migrated, changed, err := specs_format.MigrateSpecsContent(file.SpecsFileContent)
+		if err != nil {
+			_, _ = fmt.Fprintln(os.Stderr, ansi.ColorRed(fmt.Sprintf("✗ cannot migrate %s: %s", file.SpecsPath, err)))
+			continue
+		}
+		if !changed {
+			continue
+		}
+
+		if err := os.WriteFile(file.SpecsPath, migrated, 0644); err != nil {
+			_, _ = fmt.Fprintf(os.Stderr, "failed to migrate %s: %s\n", file.SpecsPath, err)
+			os.Exit(1)
+		}
+		files[i].SpecsFileContent = migrated
+		_, _ = fmt.Fprintln(os.Stdout, ansi.ColorYellow("↻ migrated "+file.SpecsPath))
+	}
+}
+
 func getTestCmd() *cobra.Command {
+	var opts testArgs
 
 	cmd := &cobra.Command{
 		Use:   "test folder...",
@@ -38,11 +72,12 @@ Defaults to "." if there are no given paths`,
 			if len(paths) == 0 {
 				paths = []string{"."}
 			}
-			runTestCmd(testArgs{
-				paths: paths,
-			})
+			opts.paths = paths
+			runTestCmd(opts)
 		},
 	}
+
+	cmd.Flags().BoolVar(&opts.migrate, "migrate", false, "rewrite specs files that use an outdated format to the current one")
 
 	return cmd
 }

--- a/internal/cmd/test_init.go
+++ b/internal/cmd/test_init.go
@@ -161,7 +161,7 @@ func makeSpecsFile(
 	}
 
 	specs := specs_format.Specs{
-		Schema:       "https://raw.githubusercontent.com/formancehq/numscript/main/v1.specs.schema.json",
+		Schema:       specs_format.SchemaURL,
 		Balances:     store.StaticStore.Balances,
 		Vars:         vars,
 		FeatureFlags: featureFlags_,

--- a/internal/interpreter/__snapshots__/pretty_print_meta_test.snap
+++ b/internal/interpreter/__snapshots__/pretty_print_meta_test.snap
@@ -1,12 +1,12 @@
 
 [TestPrettyPrintMeta/renders_plain_values - 1]
-| [36mName    [0m | [36mValue  [0m |
-| count    | 42      |
-| greeting | "hello" |
+| [36mName    [0m | [36mValue[0m |
+| count    | 42    |
+| greeting | hello |
 ---
 
-[TestPrettyPrintMeta/renders_a_scoped_account_value_in_its_source_form - 1]
-| [36mName    [0m | [36mValue                   [0m |
-| greeting | "hello"                  |
-| owner    | scoped(alice, "reserve") |
+[TestPrettyPrintMeta/renders_an_account_value_as_its_bare_name - 1]
+| [36mName    [0m | [36mValue[0m |
+| greeting | hello |
+| owner    | alice |
 ---

--- a/internal/interpreter/accounts_metadata_test.go
+++ b/internal/interpreter/accounts_metadata_test.go
@@ -8,8 +8,8 @@ import (
 )
 
 func TestCompareSetAccountsMetadata(t *testing.T) {
-	x := SetAccountMetadataRow{Account: "a", Key: "k", Value: NewMonetaryInt(1)}
-	y := SetAccountMetadataRow{Account: "a", Key: "k", Value: NewMonetaryInt(2)}
+	x := SetAccountMetadataRow{Account: "a", Key: "k", Value: "1"}
+	y := SetAccountMetadataRow{Account: "a", Key: "k", Value: "2"}
 
 	t.Run("equal regardless of order", func(t *testing.T) {
 		require.True(t, CompareSetAccountsMetadata(

--- a/internal/interpreter/evaluate_expr.go
+++ b/internal/interpreter/evaluate_expr.go
@@ -234,7 +234,7 @@ func (s *programState) evaluateColor(colorExpr parser.ValueExpr) (String, Interp
 		return "", err
 	}
 
-	isValidColor := colorRe.Match([]byte(string(color)))
+	isValidColor := checkColor(string(color))
 	if !isValidColor {
 		return "", InvalidColor{
 			Range: colorExpr.GetRange(),

--- a/internal/interpreter/interpreter.go
+++ b/internal/interpreter/interpreter.go
@@ -582,8 +582,6 @@ func (s *programState) tryTakingExact(source parser.Source, amount MonetaryInt) 
 	return nil
 }
 
-var colorRe = regexp.MustCompile("^[A-Z]*$")
-
 // PRE: overdraft >= 0
 func (s *programState) tryTakingFromAccount(accountLiteral parser.ValueExpr, amount *big.Int, overdraft *big.Int, colorExpr parser.ValueExpr) (*big.Int, InterpreterError) {
 	if colorExpr != nil {

--- a/internal/interpreter/interpreter.go
+++ b/internal/interpreter/interpreter.go
@@ -21,7 +21,10 @@ type InterpreterError interface {
 	parser.Ranged
 }
 
-type Metadata = map[string]Value
+// Metadata is the external representation of transaction metadata: keys mapped
+// to their rendered value (see MetaString). The runtime keeps the typed values in
+// programState.TxMeta and renders them when building the ExecutionResult.
+type Metadata = map[string]string
 
 type Posting struct {
 	Source           string   `json:"source"`
@@ -233,7 +236,7 @@ func RunProgram(
 
 	res := &ExecutionResult{
 		Postings:         st.Postings,
-		Metadata:         st.TxMeta,
+		Metadata:         st.txMetaToRendered(),
 		AccountsMetadata: st.SetAccountsMeta.toRows(),
 	}
 	return res, nil
@@ -254,6 +257,16 @@ type programState struct {
 	SetAccountsMeta internalSetAccountsMeta
 
 	CurrentBalanceQuery BalanceQuery
+}
+
+// txMetaToRendered renders the typed transaction metadata into the external,
+// untyped Metadata form.
+func (st *programState) txMetaToRendered() Metadata {
+	meta := make(Metadata, len(st.TxMeta))
+	for k, v := range st.TxMeta {
+		meta[k] = MetaString(v)
+	}
+	return meta
 }
 
 func (st *programState) pushSender(name AccountAddress, monetary MonetaryInt, color String) {
@@ -1067,10 +1080,5 @@ func PrettyPrintPostings(postings []Posting) string {
 }
 
 func PrettyPrintMeta(meta Metadata) string {
-	m := map[string]string{}
-	for k, v := range meta {
-		m[k] = v.String()
-	}
-
-	return utils.CsvPrettyMap("Name", "Value", m)
+	return utils.CsvPrettyMap("Name", "Value", meta)
 }

--- a/internal/interpreter/interpreter.go
+++ b/internal/interpreter/interpreter.go
@@ -128,11 +128,17 @@ func checkAccountName(addr string) bool {
 	return accountNameRegex.Match([]byte(addr))
 }
 
-var assetNameRegexp = regexp.MustCompile(`^[A-Z][A-Z0-9]{0,16}(_[A-Z]{1,16})?(\/\d{1,6})?$`)
+var assetNameRegexp = regexp.MustCompile(`^[A-Z][A-Z0-9]{0,16}(\/\d{1,6})?$`)
 
 // https://github.com/formancehq/ledger/blob/main/pkg/assets/asset.go
 func checkAssetName(v string) bool {
 	return assetNameRegexp.Match([]byte(v))
+}
+
+var colorRegexp = regexp.MustCompile(`^[A-Z]{1,16}$`)
+
+func checkColor(color string) bool {
+	return color == "" || colorRegexp.MatchString(color)
 }
 
 var scopeRegex = regexp.MustCompile(`^[a-z0-9_]*$`)
@@ -145,11 +151,13 @@ func checkScopeName(scope string) bool {
 //   - no negative postings
 //   - no invalid account names
 //   - no invalid asset names
+//   - no invalid colors
 func checkPostingInvariants(posting Posting) InterpreterError {
 	isAmtNegative := posting.Amount.Cmp(big.NewInt(0)) == -1
 
 	isInvalidPosting := (isAmtNegative ||
 		!checkAssetName(posting.Asset) ||
+		!checkColor(posting.Color) ||
 		!checkAccountName(posting.Source) ||
 		!checkAccountName(posting.Destination))
 

--- a/internal/interpreter/interpreter_error.go
+++ b/internal/interpreter/interpreter_error.go
@@ -313,7 +313,7 @@ type InvalidColor struct {
 }
 
 func (e InvalidColor) Error() string {
-	return fmt.Sprintf("Invalid color name: '%s'. Only uppercase letters are allowed.", e.Color)
+	return fmt.Sprintf("Invalid color name: '%s'. A color must be 1 to 16 uppercase letters.", e.Color)
 }
 
 type InvalidUnboundedAddressInScalingAddress struct {

--- a/internal/interpreter/pretty_print_meta_test.go
+++ b/internal/interpreter/pretty_print_meta_test.go
@@ -6,20 +6,22 @@ import (
 	"github.com/gkampitakis/go-snaps/snaps"
 )
 
+// Metadata holds already-rendered values (see MetaString), so PrettyPrintMeta
+// only has the table layout left to get right.
 func TestPrettyPrintMeta(t *testing.T) {
 	t.Run("renders plain values", func(t *testing.T) {
 		meta := Metadata{
-			"greeting": String("hello"),
-			"count":    NewMonetaryInt(42),
+			"greeting": MetaString(String("hello")),
+			"count":    MetaString(NewMonetaryInt(42)),
 		}
 
 		snaps.MatchSnapshot(t, PrettyPrintMeta(meta))
 	})
 
-	t.Run("renders a scoped account value in its source form", func(t *testing.T) {
+	t.Run("renders an account value as its bare name", func(t *testing.T) {
 		meta := Metadata{
-			"greeting": String("hello"),
-			"owner":    AccountAddress{Name: "alice", Scope: "reserve"},
+			"greeting": MetaString(String("hello")),
+			"owner":    MetaString(AccountAddress{Name: "alice"}),
 		}
 
 		snaps.MatchSnapshot(t, PrettyPrintMeta(meta))

--- a/internal/interpreter/set_accounts_metadata.go
+++ b/internal/interpreter/set_accounts_metadata.go
@@ -1,18 +1,17 @@
 package interpreter
 
 import (
-	"encoding/json"
 	"sort"
 )
 
 // SetAccountMetadataRow is a single piece of account metadata set by the script
-// during execution. Unlike the input metadata (which is opaque and string-valued,
-// since its serialization format isn't always known), the set value's type is
-// known, so it is carried as a typed Value and serialized in the tagged form.
+// during execution. The value is carried as the rendered text produced by
+// MetaString, matching the input metadata: the wire format is untyped, so a
+// value's type is not part of what gets stored or asserted.
 type SetAccountMetadataRow struct {
 	Account string `json:"account"`
 	Key     string `json:"key"`
-	Value   Value  `json:"value"`
+	Value   string `json:"value"`
 	Scope   string `json:"scope,omitempty"`
 }
 
@@ -20,37 +19,14 @@ type SetAccountMetadataRow struct {
 // execution result's accountsMeta, and a spec's expect.metadata).
 type SetAccountsMetadata []SetAccountMetadataRow
 
-func (r *SetAccountMetadataRow) UnmarshalJSON(data []byte) error {
-	var raw struct {
-		Account string          `json:"account"`
-		Key     string          `json:"key"`
-		Value   json.RawMessage `json:"value"`
-		Scope   string          `json:"scope"`
-	}
-	if err := json.Unmarshal(data, &raw); err != nil {
-		return err
-	}
-	value, err := ParseTaggedValue(raw.Value)
-	if err != nil {
-		return err
-	}
-	r.Account, r.Key, r.Scope, r.Value = raw.Account, raw.Key, raw.Scope, value
-	return nil
-}
-
 // CompareSetAccountsMetadata reports whether two lists hold the same rows,
-// ignoring order but respecting multiplicity (so [x, x] != [x, y]). Values are
-// compared on their canonical source form.
+// ignoring order but respecting multiplicity (so [x, x] != [x, y]).
 func CompareSetAccountsMetadata(a SetAccountsMetadata, b SetAccountsMetadata) bool {
 	if len(a) != len(b) {
 		return false
 	}
 	key := func(r SetAccountMetadataRow) string {
-		value := ""
-		if r.Value != nil {
-			value = r.Value.String()
-		}
-		return r.Account + "\x00" + r.Key + "\x00" + r.Scope + "\x00" + value
+		return r.Account + "\x00" + r.Key + "\x00" + r.Scope + "\x00" + r.Value
 	}
 	counts := make(map[string]int, len(a))
 	for _, r := range a {
@@ -75,7 +51,8 @@ func (m internalSetAccountsMeta) Set(account, scope, key string, value Value) {
 }
 
 // toRows flattens the set metadata into the external representation, sorted by
-// (account, scope, key) for deterministic output.
+// (account, scope, key) for deterministic output. Values are rendered here: the
+// runtime keeps them typed, the wire format does not.
 func (m internalSetAccountsMeta) toRows() SetAccountsMetadata {
 	rows := make(SetAccountsMetadata, 0, len(m))
 	for k, value := range m {
@@ -83,7 +60,7 @@ func (m internalSetAccountsMeta) toRows() SetAccountsMetadata {
 			Account: k.Account,
 			Scope:   k.Scope,
 			Key:     k.Key,
-			Value:   value,
+			Value:   MetaString(value),
 		})
 	}
 	sort.Slice(rows, func(i, j int) bool {

--- a/internal/interpreter/testdata/numscript-cookbook/experimental/meta-calc.num.specs.json
+++ b/internal/interpreter/testdata/numscript-cookbook/experimental/meta-calc.num.specs.json
@@ -9,7 +9,7 @@
     {
       "it": "sets the expected meta",
       "expect.txMetadata": [
-        { "key": "key", "value": { "type": "portion", "numerator": "11", "denominator": "2" } }
+        { "key": "key", "value": "11/2" }
       ]
     }
   ]

--- a/internal/interpreter/testdata/numscript-cookbook/experimental/meta-calc.num.specs.json
+++ b/internal/interpreter/testdata/numscript-cookbook/experimental/meta-calc.num.specs.json
@@ -9,7 +9,10 @@
     {
       "it": "sets the expected meta",
       "expect.txMetadata": [
-        { "key": "key", "value": "11/2" }
+        {
+          "key": "key",
+          "value": "11/2"
+        }
       ]
     }
   ]

--- a/internal/interpreter/testdata/script-tests/add-monetaries-same-currency.num.specs.json
+++ b/internal/interpreter/testdata/script-tests/add-monetaries-same-currency.num.specs.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://raw.githubusercontent.com/formancehq/numscript/main/v1.specs.schema.json",
   "testCases": [
     {
       "it": "-",

--- a/internal/interpreter/testdata/script-tests/add-numbers.num.specs.json
+++ b/internal/interpreter/testdata/script-tests/add-numbers.num.specs.json
@@ -1,9 +1,13 @@
 {
+  "$schema": "https://raw.githubusercontent.com/formancehq/numscript/main/v1.specs.schema.json",
   "testCases": [
     {
       "it": "-",
       "expect.txMetadata": [
-        { "key": "k", "value": "3" }
+        {
+          "key": "k",
+          "value": "3"
+        }
       ]
     }
   ]

--- a/internal/interpreter/testdata/script-tests/add-numbers.num.specs.json
+++ b/internal/interpreter/testdata/script-tests/add-numbers.num.specs.json
@@ -3,7 +3,7 @@
     {
       "it": "-",
       "expect.txMetadata": [
-        { "key": "k", "value": { "type": "number", "value": "3" } }
+        { "key": "k", "value": "3" }
       ]
     }
   ]

--- a/internal/interpreter/testdata/script-tests/allocate-dont-take-too-much.num.specs.json
+++ b/internal/interpreter/testdata/script-tests/allocate-dont-take-too-much.num.specs.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://raw.githubusercontent.com/formancehq/numscript/main/v1.specs.schema.json",
   "testCases": [
     {
       "it": "-",

--- a/internal/interpreter/testdata/script-tests/allocation.num.specs.json
+++ b/internal/interpreter/testdata/script-tests/allocation.num.specs.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://raw.githubusercontent.com/formancehq/numscript/main/v1.specs.schema.json",
   "testCases": [
     {
       "it": "-",

--- a/internal/interpreter/testdata/script-tests/ask-balance-twice.num.specs.json
+++ b/internal/interpreter/testdata/script-tests/ask-balance-twice.num.specs.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://raw.githubusercontent.com/formancehq/numscript/main/v1.specs.schema.json",
   "testCases": [
     {
       "it": "-",

--- a/internal/interpreter/testdata/script-tests/balance-not-found.num.specs.json
+++ b/internal/interpreter/testdata/script-tests/balance-not-found.num.specs.json
@@ -1,9 +1,8 @@
 {
+  "$schema": "https://raw.githubusercontent.com/formancehq/numscript/main/v1.specs.schema.json",
   "testCases": [
     {
-      "it": "-",
-      "balances": [],
-      "expect.postings": []
+      "it": "-"
     }
   ]
 }

--- a/internal/interpreter/testdata/script-tests/balance-simple.num.specs.json
+++ b/internal/interpreter/testdata/script-tests/balance-simple.num.specs.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://raw.githubusercontent.com/formancehq/numscript/main/v1.specs.schema.json",
   "testCases": [
     {
       "it": "-",

--- a/internal/interpreter/testdata/script-tests/balance.num.specs.json
+++ b/internal/interpreter/testdata/script-tests/balance.num.specs.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://raw.githubusercontent.com/formancehq/numscript/main/v1.specs.schema.json",
   "testCases": [
     {
       "it": "-",

--- a/internal/interpreter/testdata/script-tests/big-int-monetary.num.specs.json
+++ b/internal/interpreter/testdata/script-tests/big-int-monetary.num.specs.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://raw.githubusercontent.com/formancehq/numscript/main/v1.specs.schema.json",
   "testCases": [
     {
       "it": "-",

--- a/internal/interpreter/testdata/script-tests/big-int.num.specs.json
+++ b/internal/interpreter/testdata/script-tests/big-int.num.specs.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://raw.githubusercontent.com/formancehq/numscript/main/v1.specs.schema.json",
   "testCases": [
     {
       "it": "-",

--- a/internal/interpreter/testdata/script-tests/capped-when-less-than-needed.num.specs.json
+++ b/internal/interpreter/testdata/script-tests/capped-when-less-than-needed.num.specs.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://raw.githubusercontent.com/formancehq/numscript/main/v1.specs.schema.json",
   "testCases": [
     {
       "it": "-",

--- a/internal/interpreter/testdata/script-tests/capped-when-more-than-balance.num.specs.json
+++ b/internal/interpreter/testdata/script-tests/capped-when-more-than-balance.num.specs.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://raw.githubusercontent.com/formancehq/numscript/main/v1.specs.schema.json",
   "testCases": [
     {
       "it": "-",

--- a/internal/interpreter/testdata/script-tests/cascading-sources.num.specs.json
+++ b/internal/interpreter/testdata/script-tests/cascading-sources.num.specs.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://raw.githubusercontent.com/formancehq/numscript/main/v1.specs.schema.json",
   "testCases": [
     {
       "it": "-",

--- a/internal/interpreter/testdata/script-tests/destination-complex.num.specs.json
+++ b/internal/interpreter/testdata/script-tests/destination-complex.num.specs.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://raw.githubusercontent.com/formancehq/numscript/main/v1.specs.schema.json",
   "testCases": [
     {
       "it": "-",

--- a/internal/interpreter/testdata/script-tests/do-not-exceed-overdraft-on-send-all.num.specs.json
+++ b/internal/interpreter/testdata/script-tests/do-not-exceed-overdraft-on-send-all.num.specs.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://raw.githubusercontent.com/formancehq/numscript/main/v1.specs.schema.json",
   "testCases": [
     {
       "it": "-",

--- a/internal/interpreter/testdata/script-tests/do-not-exceed-overdraft-when-double-spending.num.specs.json
+++ b/internal/interpreter/testdata/script-tests/do-not-exceed-overdraft-when-double-spending.num.specs.json
@@ -1,8 +1,8 @@
 {
+  "$schema": "https://raw.githubusercontent.com/formancehq/numscript/main/v1.specs.schema.json",
   "testCases": [
     {
       "it": "-",
-      "balances": [],
       "expect.postings": [
         {
           "source": "s",

--- a/internal/interpreter/testdata/script-tests/do-not-exceed-overdraft.num.specs.json
+++ b/internal/interpreter/testdata/script-tests/do-not-exceed-overdraft.num.specs.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://raw.githubusercontent.com/formancehq/numscript/main/v1.specs.schema.json",
   "testCases": [
     {
       "it": "-",

--- a/internal/interpreter/testdata/script-tests/dynamic-allocation.num.specs.json
+++ b/internal/interpreter/testdata/script-tests/dynamic-allocation.num.specs.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://raw.githubusercontent.com/formancehq/numscript/main/v1.specs.schema.json",
   "testCases": [
     {
       "it": "-",

--- a/internal/interpreter/testdata/script-tests/empty-postings.num.specs.json
+++ b/internal/interpreter/testdata/script-tests/empty-postings.num.specs.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://raw.githubusercontent.com/formancehq/numscript/main/v1.specs.schema.json",
   "testCases": [
     {
       "it": "-",
@@ -8,8 +9,7 @@
           "asset": "GEM",
           "amount": 0
         }
-      ],
-      "expect.postings": []
+      ]
     }
   ]
 }

--- a/internal/interpreter/testdata/script-tests/experimental/account-interpolation/account-interp.num.specs.json
+++ b/internal/interpreter/testdata/script-tests/experimental/account-interpolation/account-interp.num.specs.json
@@ -11,7 +11,7 @@
         "status": "pending"
       },
       "expect.txMetadata": [
-        { "key": "k", "value": { "type": "account", "name": "acc:42:pending:user:001" } }
+        { "key": "k", "value": "acc:42:pending:user:001" }
       ]
     }
   ]

--- a/internal/interpreter/testdata/script-tests/experimental/account-interpolation/account-interp.num.specs.json
+++ b/internal/interpreter/testdata/script-tests/experimental/account-interpolation/account-interp.num.specs.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://raw.githubusercontent.com/formancehq/numscript/main/v1.specs.schema.json",
   "featureFlags": [
     "experimental-account-interpolation"
   ],
@@ -11,7 +12,10 @@
         "status": "pending"
       },
       "expect.txMetadata": [
-        { "key": "k", "value": "acc:42:pending:user:001" }
+        {
+          "key": "k",
+          "value": "acc:42:pending:user:001"
+        }
       ]
     }
   ]

--- a/internal/interpreter/testdata/script-tests/experimental/asset-colors/color-inorder-send-all.num.specs.json
+++ b/internal/interpreter/testdata/script-tests/experimental/asset-colors/color-inorder-send-all.num.specs.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://raw.githubusercontent.com/formancehq/numscript/main/v1.specs.schema.json",
   "featureFlags": [
     "experimental-asset-colors"
   ],

--- a/internal/interpreter/testdata/script-tests/experimental/asset-colors/color-inorder.num.specs.json
+++ b/internal/interpreter/testdata/script-tests/experimental/asset-colors/color-inorder.num.specs.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://raw.githubusercontent.com/formancehq/numscript/main/v1.specs.schema.json",
   "featureFlags": [
     "experimental-asset-colors"
   ],

--- a/internal/interpreter/testdata/script-tests/experimental/asset-colors/color-restrict-balance-when-missing-funds.num.specs.json
+++ b/internal/interpreter/testdata/script-tests/experimental/asset-colors/color-restrict-balance-when-missing-funds.num.specs.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://raw.githubusercontent.com/formancehq/numscript/main/v1.specs.schema.json",
   "featureFlags": [
     "experimental-asset-colors"
   ],

--- a/internal/interpreter/testdata/script-tests/experimental/asset-colors/color-restrict-balance-when-missing-funds.num.specs.json
+++ b/internal/interpreter/testdata/script-tests/experimental/asset-colors/color-restrict-balance-when-missing-funds.num.specs.json
@@ -14,7 +14,8 @@
         },
         {
           "account": "acc",
-          "asset": "COIN_RED",
+          "asset": "COIN",
+          "color": "RED",
           "amount": 1
         }
       ],

--- a/internal/interpreter/testdata/script-tests/experimental/asset-colors/color-restrict-balance.num.specs.json
+++ b/internal/interpreter/testdata/script-tests/experimental/asset-colors/color-restrict-balance.num.specs.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://raw.githubusercontent.com/formancehq/numscript/main/v1.specs.schema.json",
   "featureFlags": [
     "experimental-asset-colors"
   ],

--- a/internal/interpreter/testdata/script-tests/experimental/asset-colors/color-restriction-in-send-all.num.specs.json
+++ b/internal/interpreter/testdata/script-tests/experimental/asset-colors/color-restriction-in-send-all.num.specs.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://raw.githubusercontent.com/formancehq/numscript/main/v1.specs.schema.json",
   "featureFlags": [
     "experimental-asset-colors"
   ],

--- a/internal/interpreter/testdata/script-tests/experimental/asset-colors/color-send-overdrat.num.specs.json
+++ b/internal/interpreter/testdata/script-tests/experimental/asset-colors/color-send-overdrat.num.specs.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://raw.githubusercontent.com/formancehq/numscript/main/v1.specs.schema.json",
   "featureFlags": [
     "experimental-asset-colors"
   ],

--- a/internal/interpreter/testdata/script-tests/experimental/asset-colors/color-send.num.specs.json
+++ b/internal/interpreter/testdata/script-tests/experimental/asset-colors/color-send.num.specs.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://raw.githubusercontent.com/formancehq/numscript/main/v1.specs.schema.json",
   "featureFlags": [
     "experimental-asset-colors"
   ],

--- a/internal/interpreter/testdata/script-tests/experimental/asset-colors/color-with-asset-precision.num.specs.json
+++ b/internal/interpreter/testdata/script-tests/experimental/asset-colors/color-with-asset-precision.num.specs.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://raw.githubusercontent.com/formancehq/numscript/main/v1.specs.schema.json",
   "featureFlags": [
     "experimental-asset-colors"
   ],

--- a/internal/interpreter/testdata/script-tests/experimental/asset-colors/empty-color.num.specs.json
+++ b/internal/interpreter/testdata/script-tests/experimental/asset-colors/empty-color.num.specs.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://raw.githubusercontent.com/formancehq/numscript/main/v1.specs.schema.json",
   "featureFlags": [
     "experimental-asset-colors"
   ],

--- a/internal/interpreter/testdata/script-tests/experimental/asset-colors/no-double-spending-in-colored-send-all.num.specs.json
+++ b/internal/interpreter/testdata/script-tests/experimental/asset-colors/no-double-spending-in-colored-send-all.num.specs.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://raw.githubusercontent.com/formancehq/numscript/main/v1.specs.schema.json",
   "featureFlags": [
     "experimental-asset-colors"
   ],

--- a/internal/interpreter/testdata/script-tests/experimental/asset-colors/no-double-spending-in-colored-send.num.specs.json
+++ b/internal/interpreter/testdata/script-tests/experimental/asset-colors/no-double-spending-in-colored-send.num.specs.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://raw.githubusercontent.com/formancehq/numscript/main/v1.specs.schema.json",
   "featureFlags": [
     "experimental-asset-colors"
   ],

--- a/internal/interpreter/testdata/script-tests/experimental/get-amount-function/get-amount-function.num.specs.json
+++ b/internal/interpreter/testdata/script-tests/experimental/get-amount-function/get-amount-function.num.specs.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://raw.githubusercontent.com/formancehq/numscript/main/v1.specs.schema.json",
   "featureFlags": [
     "experimental-get-amount-function"
   ],
@@ -6,7 +7,10 @@
     {
       "it": "-",
       "expect.txMetadata": [
-        { "key": "amt", "value": "100" }
+        {
+          "key": "amt",
+          "value": "100"
+        }
       ]
     }
   ]

--- a/internal/interpreter/testdata/script-tests/experimental/get-amount-function/get-amount-function.num.specs.json
+++ b/internal/interpreter/testdata/script-tests/experimental/get-amount-function/get-amount-function.num.specs.json
@@ -6,7 +6,7 @@
     {
       "it": "-",
       "expect.txMetadata": [
-        { "key": "amt", "value": { "type": "number", "value": "100" } }
+        { "key": "amt", "value": "100" }
       ]
     }
   ]

--- a/internal/interpreter/testdata/script-tests/experimental/get-asset-function/get-asset-function.num.specs.json
+++ b/internal/interpreter/testdata/script-tests/experimental/get-asset-function/get-asset-function.num.specs.json
@@ -6,7 +6,7 @@
     {
       "it": "-",
       "expect.txMetadata": [
-        { "key": "asset", "value": { "type": "asset", "name": "ABC" } }
+        { "key": "asset", "value": "ABC" }
       ]
     }
   ]

--- a/internal/interpreter/testdata/script-tests/experimental/get-asset-function/get-asset-function.num.specs.json
+++ b/internal/interpreter/testdata/script-tests/experimental/get-asset-function/get-asset-function.num.specs.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://raw.githubusercontent.com/formancehq/numscript/main/v1.specs.schema.json",
   "featureFlags": [
     "experimental-get-asset-function"
   ],
@@ -6,7 +7,10 @@
     {
       "it": "-",
       "expect.txMetadata": [
-        { "key": "asset", "value": "ABC" }
+        {
+          "key": "asset",
+          "value": "ABC"
+        }
       ]
     }
   ]

--- a/internal/interpreter/testdata/script-tests/experimental/mid-script-function-call/expr-in-var-origin.num.specs.json
+++ b/internal/interpreter/testdata/script-tests/experimental/mid-script-function-call/expr-in-var-origin.num.specs.json
@@ -1,11 +1,11 @@
 {
+  "$schema": "https://raw.githubusercontent.com/formancehq/numscript/main/v1.specs.schema.json",
   "featureFlags": [
     "experimental-mid-script-function-call"
   ],
   "testCases": [
     {
-      "it": "-",
-      "expect.postings": []
+      "it": "-"
     }
   ]
 }

--- a/internal/interpreter/testdata/script-tests/experimental/mid-script-function-call/midscript-balance-after-decrease.num.specs.json
+++ b/internal/interpreter/testdata/script-tests/experimental/mid-script-function-call/midscript-balance-after-decrease.num.specs.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://raw.githubusercontent.com/formancehq/numscript/main/v1.specs.schema.json",
   "featureFlags": [
     "experimental-mid-script-function-call"
   ],

--- a/internal/interpreter/testdata/script-tests/experimental/mid-script-function-call/midscript-balance.num.specs.json
+++ b/internal/interpreter/testdata/script-tests/experimental/mid-script-function-call/midscript-balance.num.specs.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://raw.githubusercontent.com/formancehq/numscript/main/v1.specs.schema.json",
   "featureFlags": [
     "experimental-mid-script-function-call"
   ],

--- a/internal/interpreter/testdata/script-tests/experimental/oneof/oneof-all-failing.num.specs.json
+++ b/internal/interpreter/testdata/script-tests/experimental/oneof/oneof-all-failing.num.specs.json
@@ -1,11 +1,11 @@
 {
+  "$schema": "https://raw.githubusercontent.com/formancehq/numscript/main/v1.specs.schema.json",
   "featureFlags": [
     "experimental-oneof"
   ],
   "testCases": [
     {
       "it": "-",
-      "balances": [],
       "expect.error.missingFunds": true
     }
   ]

--- a/internal/interpreter/testdata/script-tests/experimental/oneof/oneof-destination-first-clause.num.specs.json
+++ b/internal/interpreter/testdata/script-tests/experimental/oneof/oneof-destination-first-clause.num.specs.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://raw.githubusercontent.com/formancehq/numscript/main/v1.specs.schema.json",
   "featureFlags": [
     "experimental-oneof"
   ],

--- a/internal/interpreter/testdata/script-tests/experimental/oneof/oneof-destination-remaining-clause.num.specs.json
+++ b/internal/interpreter/testdata/script-tests/experimental/oneof/oneof-destination-remaining-clause.num.specs.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://raw.githubusercontent.com/formancehq/numscript/main/v1.specs.schema.json",
   "featureFlags": [
     "experimental-oneof"
   ],

--- a/internal/interpreter/testdata/script-tests/experimental/oneof/oneof-destination-second-clause.num.specs.json
+++ b/internal/interpreter/testdata/script-tests/experimental/oneof/oneof-destination-second-clause.num.specs.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://raw.githubusercontent.com/formancehq/numscript/main/v1.specs.schema.json",
   "featureFlags": [
     "experimental-oneof"
   ],

--- a/internal/interpreter/testdata/script-tests/experimental/oneof/oneof-in-send-all.num.specs.json
+++ b/internal/interpreter/testdata/script-tests/experimental/oneof/oneof-in-send-all.num.specs.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://raw.githubusercontent.com/formancehq/numscript/main/v1.specs.schema.json",
   "featureFlags": [
     "experimental-oneof"
   ],

--- a/internal/interpreter/testdata/script-tests/experimental/oneof/oneof-in-source-send-first-branch.num.specs.json
+++ b/internal/interpreter/testdata/script-tests/experimental/oneof/oneof-in-source-send-first-branch.num.specs.json
@@ -1,11 +1,11 @@
 {
+  "$schema": "https://raw.githubusercontent.com/formancehq/numscript/main/v1.specs.schema.json",
   "featureFlags": [
     "experimental-oneof"
   ],
   "testCases": [
     {
       "it": "-",
-      "balances": [],
       "expect.postings": [
         {
           "source": "a",

--- a/internal/interpreter/testdata/script-tests/experimental/oneof/oneof-in-source.num.specs.json
+++ b/internal/interpreter/testdata/script-tests/experimental/oneof/oneof-in-source.num.specs.json
@@ -1,11 +1,11 @@
 {
+  "$schema": "https://raw.githubusercontent.com/formancehq/numscript/main/v1.specs.schema.json",
   "featureFlags": [
     "experimental-oneof"
   ],
   "testCases": [
     {
       "it": "-",
-      "balances": [],
       "expect.postings": [
         {
           "source": "world",

--- a/internal/interpreter/testdata/script-tests/experimental/oneof/oneof-singleton.num.specs.json
+++ b/internal/interpreter/testdata/script-tests/experimental/oneof/oneof-singleton.num.specs.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://raw.githubusercontent.com/formancehq/numscript/main/v1.specs.schema.json",
   "featureFlags": [
     "experimental-oneof"
   ],

--- a/internal/interpreter/testdata/script-tests/experimental/oneof/update-balances-with-oneof.num.specs.json
+++ b/internal/interpreter/testdata/script-tests/experimental/oneof/update-balances-with-oneof.num.specs.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://raw.githubusercontent.com/formancehq/numscript/main/v1.specs.schema.json",
   "featureFlags": [
     "experimental-oneof"
   ],

--- a/internal/interpreter/testdata/script-tests/experimental/overdraft-function/overdraft-function-use-case-remove-debt.num.specs.json
+++ b/internal/interpreter/testdata/script-tests/experimental/overdraft-function/overdraft-function-use-case-remove-debt.num.specs.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://raw.githubusercontent.com/formancehq/numscript/main/v1.specs.schema.json",
   "featureFlags": [
     "experimental-overdraft-function"
   ],

--- a/internal/interpreter/testdata/script-tests/experimental/overdraft-function/overdraft-function-when-negative.num.specs.json
+++ b/internal/interpreter/testdata/script-tests/experimental/overdraft-function/overdraft-function-when-negative.num.specs.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://raw.githubusercontent.com/formancehq/numscript/main/v1.specs.schema.json",
   "featureFlags": [
     "experimental-overdraft-function"
   ],

--- a/internal/interpreter/testdata/script-tests/experimental/overdraft-function/overdraft-function-when-positive.num.specs.json
+++ b/internal/interpreter/testdata/script-tests/experimental/overdraft-function/overdraft-function-when-positive.num.specs.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://raw.githubusercontent.com/formancehq/numscript/main/v1.specs.schema.json",
   "featureFlags": [
     "experimental-overdraft-function"
   ],
@@ -11,8 +12,7 @@
           "asset": "EUR/2",
           "amount": 100
         }
-      ],
-      "expect.postings": []
+      ]
     }
   ]
 }

--- a/internal/interpreter/testdata/script-tests/experimental/overdraft-function/overdraft-function-when-zero.num.specs.json
+++ b/internal/interpreter/testdata/script-tests/experimental/overdraft-function/overdraft-function-when-zero.num.specs.json
@@ -1,12 +1,11 @@
 {
+  "$schema": "https://raw.githubusercontent.com/formancehq/numscript/main/v1.specs.schema.json",
   "featureFlags": [
     "experimental-overdraft-function"
   ],
   "testCases": [
     {
-      "it": "-",
-      "balances": [],
-      "expect.postings": []
+      "it": "-"
     }
   ]
 }

--- a/internal/interpreter/testdata/script-tests/experimental/overdraft-function/reach-zero.num.specs.json
+++ b/internal/interpreter/testdata/script-tests/experimental/overdraft-function/reach-zero.num.specs.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/formancehq/numscript/29a351f9aa5ae03d72b85f55981e52dd57e81c07/specs.schema.json",
+  "$schema": "https://raw.githubusercontent.com/formancehq/numscript/main/v1.specs.schema.json",
   "variables": {
     "amt": "100"
   },

--- a/internal/interpreter/testdata/script-tests/experimental/scoped-function/set-account-meta.num.specs.json
+++ b/internal/interpreter/testdata/script-tests/experimental/scoped-function/set-account-meta.num.specs.json
@@ -8,8 +8,8 @@
     {
       "it": "sets metadata scoped by the account's scope, distinct from the unscoped entry",
       "expect.metadata": [
-        { "account": "acc", "key": "k", "value": { "type": "string", "value": "unscoped" } },
-        { "account": "acc", "scope": "myscope", "key": "k", "value": { "type": "string", "value": "scoped" } }
+        { "account": "acc", "key": "k", "value": "unscoped" },
+        { "account": "acc", "scope": "myscope", "key": "k", "value": "scoped" }
       ]
     }
   ]

--- a/internal/interpreter/testdata/script-tests/experimental/scoped-function/set-account-meta.num.specs.json
+++ b/internal/interpreter/testdata/script-tests/experimental/scoped-function/set-account-meta.num.specs.json
@@ -8,8 +8,17 @@
     {
       "it": "sets metadata scoped by the account's scope, distinct from the unscoped entry",
       "expect.metadata": [
-        { "account": "acc", "key": "k", "value": "unscoped" },
-        { "account": "acc", "scope": "myscope", "key": "k", "value": "scoped" }
+        {
+          "account": "acc",
+          "key": "k",
+          "value": "unscoped"
+        },
+        {
+          "account": "acc",
+          "key": "k",
+          "value": "scoped",
+          "scope": "myscope"
+        }
       ]
     }
   ]

--- a/internal/interpreter/testdata/script-tests/inoder-destination.num.specs.json
+++ b/internal/interpreter/testdata/script-tests/inoder-destination.num.specs.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://raw.githubusercontent.com/formancehq/numscript/main/v1.specs.schema.json",
   "testCases": [
     {
       "it": "-",

--- a/internal/interpreter/testdata/script-tests/insufficient-funds.num.specs.json
+++ b/internal/interpreter/testdata/script-tests/insufficient-funds.num.specs.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://raw.githubusercontent.com/formancehq/numscript/main/v1.specs.schema.json",
   "testCases": [
     {
       "it": "-",

--- a/internal/interpreter/testdata/script-tests/kept-in-send-all-inorder.num.specs.json
+++ b/internal/interpreter/testdata/script-tests/kept-in-send-all-inorder.num.specs.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://raw.githubusercontent.com/formancehq/numscript/main/v1.specs.schema.json",
   "testCases": [
     {
       "it": "-",

--- a/internal/interpreter/testdata/script-tests/kept-inorder.num.specs.json
+++ b/internal/interpreter/testdata/script-tests/kept-inorder.num.specs.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://raw.githubusercontent.com/formancehq/numscript/main/v1.specs.schema.json",
   "testCases": [
     {
       "it": "-",

--- a/internal/interpreter/testdata/script-tests/kept-with-balance.num.specs.json
+++ b/internal/interpreter/testdata/script-tests/kept-with-balance.num.specs.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://raw.githubusercontent.com/formancehq/numscript/main/v1.specs.schema.json",
   "testCases": [
     {
       "it": "-",

--- a/internal/interpreter/testdata/script-tests/many-kept-dest.num.specs.json
+++ b/internal/interpreter/testdata/script-tests/many-kept-dest.num.specs.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://raw.githubusercontent.com/formancehq/numscript/main/v1.specs.schema.json",
   "testCases": [
     {
       "it": "-",

--- a/internal/interpreter/testdata/script-tests/many-max-dest.num.specs.json
+++ b/internal/interpreter/testdata/script-tests/many-max-dest.num.specs.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://raw.githubusercontent.com/formancehq/numscript/main/v1.specs.schema.json",
   "testCases": [
     {
       "it": "-",

--- a/internal/interpreter/testdata/script-tests/max-with-unbounded-overdraft.num.specs.json
+++ b/internal/interpreter/testdata/script-tests/max-with-unbounded-overdraft.num.specs.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://raw.githubusercontent.com/formancehq/numscript/main/v1.specs.schema.json",
   "testCases": [
     {
       "it": "-",

--- a/internal/interpreter/testdata/script-tests/metadata.num.specs.json
+++ b/internal/interpreter/testdata/script-tests/metadata.num.specs.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://raw.githubusercontent.com/formancehq/numscript/main/v1.specs.schema.json",
   "testCases": [
     {
       "it": "-",
@@ -18,8 +19,16 @@
         "sale": "sales:042"
       },
       "metadata": [
-        { "account": "sales:042", "key": "seller", "value": "users:053" },
-        { "account": "users:053", "key": "commission", "value": "12.5%" }
+        {
+          "account": "sales:042",
+          "key": "seller",
+          "value": "users:053"
+        },
+        {
+          "account": "users:053",
+          "key": "commission",
+          "value": "12.5%"
+        }
       ],
       "expect.postings": [
         {

--- a/internal/interpreter/testdata/script-tests/neg-max-dest.num.specs.json
+++ b/internal/interpreter/testdata/script-tests/neg-max-dest.num.specs.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://raw.githubusercontent.com/formancehq/numscript/main/v1.specs.schema.json",
   "testCases": [
     {
       "it": "-",
@@ -9,14 +10,12 @@
           "amount": 99999999
         }
       ],
-      "variables": {},
-      "metadata": [],
       "expect.postings": [
         {
           "source": "memo:main",
           "destination": "world",
-          "asset": "EUR/2",
-          "amount": 100
+          "amount": 100,
+          "asset": "EUR/2"
         }
       ]
     }

--- a/internal/interpreter/testdata/script-tests/negative-max-send-all.num.specs.json
+++ b/internal/interpreter/testdata/script-tests/negative-max-send-all.num.specs.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://raw.githubusercontent.com/formancehq/numscript/main/v1.specs.schema.json",
   "testCases": [
     {
       "it": "-",
@@ -8,8 +9,7 @@
           "asset": "USD/2",
           "amount": 0
         }
-      ],
-      "expect.postings": []
+      ]
     }
   ]
 }

--- a/internal/interpreter/testdata/script-tests/negative-max.num.specs.json
+++ b/internal/interpreter/testdata/script-tests/negative-max.num.specs.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://raw.githubusercontent.com/formancehq/numscript/main/v1.specs.schema.json",
   "testCases": [
     {
       "it": "-",

--- a/internal/interpreter/testdata/script-tests/nested-remaining-complex.num.specs.json
+++ b/internal/interpreter/testdata/script-tests/nested-remaining-complex.num.specs.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://raw.githubusercontent.com/formancehq/numscript/main/v1.specs.schema.json",
   "testCases": [
     {
       "it": "-",

--- a/internal/interpreter/testdata/script-tests/nested-remaining.num.specs.json
+++ b/internal/interpreter/testdata/script-tests/nested-remaining.num.specs.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://raw.githubusercontent.com/formancehq/numscript/main/v1.specs.schema.json",
   "testCases": [
     {
       "it": "-",

--- a/internal/interpreter/testdata/script-tests/no-empty-postings.num.specs.json
+++ b/internal/interpreter/testdata/script-tests/no-empty-postings.num.specs.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://raw.githubusercontent.com/formancehq/numscript/main/v1.specs.schema.json",
   "testCases": [
     {
       "it": "-",

--- a/internal/interpreter/testdata/script-tests/ovedrafts-playground-example.num.specs.json
+++ b/internal/interpreter/testdata/script-tests/ovedrafts-playground-example.num.specs.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://raw.githubusercontent.com/formancehq/numscript/main/v1.specs.schema.json",
   "testCases": [
     {
       "it": "-",

--- a/internal/interpreter/testdata/script-tests/overdraft-in-send-all-when-noop.num.specs.json
+++ b/internal/interpreter/testdata/script-tests/overdraft-in-send-all-when-noop.num.specs.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://raw.githubusercontent.com/formancehq/numscript/main/v1.specs.schema.json",
   "testCases": [
     {
       "it": "-",

--- a/internal/interpreter/testdata/script-tests/overdraft-in-send-all.num.specs.json
+++ b/internal/interpreter/testdata/script-tests/overdraft-in-send-all.num.specs.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://raw.githubusercontent.com/formancehq/numscript/main/v1.specs.schema.json",
   "testCases": [
     {
       "it": "-",

--- a/internal/interpreter/testdata/script-tests/overdraft-not-enough-funds.num.specs.json
+++ b/internal/interpreter/testdata/script-tests/overdraft-not-enough-funds.num.specs.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://raw.githubusercontent.com/formancehq/numscript/main/v1.specs.schema.json",
   "testCases": [
     {
       "it": "-",

--- a/internal/interpreter/testdata/script-tests/overdraft-when-enough-funds.num.specs.json
+++ b/internal/interpreter/testdata/script-tests/overdraft-when-enough-funds.num.specs.json
@@ -1,8 +1,8 @@
 {
+  "$schema": "https://raw.githubusercontent.com/formancehq/numscript/main/v1.specs.schema.json",
   "testCases": [
     {
       "it": "-",
-      "balances": [],
       "expect.postings": [
         {
           "source": "users:1234",

--- a/internal/interpreter/testdata/script-tests/overdraft-when-negative-balance-in-send-all.num.specs.json
+++ b/internal/interpreter/testdata/script-tests/overdraft-when-negative-balance-in-send-all.num.specs.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://raw.githubusercontent.com/formancehq/numscript/main/v1.specs.schema.json",
   "testCases": [
     {
       "it": "-",

--- a/internal/interpreter/testdata/script-tests/overdraft-when-negative-balance.num.specs.json
+++ b/internal/interpreter/testdata/script-tests/overdraft-when-negative-balance.num.specs.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://raw.githubusercontent.com/formancehq/numscript/main/v1.specs.schema.json",
   "testCases": [
     {
       "it": "-",

--- a/internal/interpreter/testdata/script-tests/overdraft-when-negative-ovedraft-in-send-all.num.specs.json
+++ b/internal/interpreter/testdata/script-tests/overdraft-when-negative-ovedraft-in-send-all.num.specs.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://raw.githubusercontent.com/formancehq/numscript/main/v1.specs.schema.json",
   "testCases": [
     {
       "it": "-",

--- a/internal/interpreter/testdata/script-tests/overdraft-when-not-enough-funds.num.specs.json
+++ b/internal/interpreter/testdata/script-tests/overdraft-when-not-enough-funds.num.specs.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://raw.githubusercontent.com/formancehq/numscript/main/v1.specs.schema.json",
   "testCases": [
     {
       "it": "-",

--- a/internal/interpreter/testdata/script-tests/override-account-meta.num.specs.json
+++ b/internal/interpreter/testdata/script-tests/override-account-meta.num.specs.json
@@ -7,8 +7,8 @@
         { "account": "acc", "key": "overridden", "value": "1" }
       ],
       "expect.metadata": [
-        { "account": "acc", "key": "new", "value": { "type": "number", "value": "2" } },
-        { "account": "acc", "key": "overridden", "value": { "type": "number", "value": "100" } }
+        { "account": "acc", "key": "new", "value": "2" },
+        { "account": "acc", "key": "overridden", "value": "100" }
       ]
     }
   ]

--- a/internal/interpreter/testdata/script-tests/override-account-meta.num.specs.json
+++ b/internal/interpreter/testdata/script-tests/override-account-meta.num.specs.json
@@ -1,14 +1,31 @@
 {
+  "$schema": "https://raw.githubusercontent.com/formancehq/numscript/main/v1.specs.schema.json",
   "testCases": [
     {
       "it": "-",
       "metadata": [
-        { "account": "acc", "key": "initial", "value": "0" },
-        { "account": "acc", "key": "overridden", "value": "1" }
+        {
+          "account": "acc",
+          "key": "initial",
+          "value": "0"
+        },
+        {
+          "account": "acc",
+          "key": "overridden",
+          "value": "1"
+        }
       ],
       "expect.metadata": [
-        { "account": "acc", "key": "new", "value": "2" },
-        { "account": "acc", "key": "overridden", "value": "100" }
+        {
+          "account": "acc",
+          "key": "new",
+          "value": "2"
+        },
+        {
+          "account": "acc",
+          "key": "overridden",
+          "value": "100"
+        }
       ]
     }
   ]

--- a/internal/interpreter/testdata/script-tests/portion-syntax.num.specs.json
+++ b/internal/interpreter/testdata/script-tests/portion-syntax.num.specs.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://raw.githubusercontent.com/formancehq/numscript/main/v1.specs.schema.json",
   "testCases": [
     {
       "it": "-",

--- a/internal/interpreter/testdata/script-tests/remaining-kept-in-send-all-inorder.num.specs.json
+++ b/internal/interpreter/testdata/script-tests/remaining-kept-in-send-all-inorder.num.specs.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://raw.githubusercontent.com/formancehq/numscript/main/v1.specs.schema.json",
   "testCases": [
     {
       "it": "-",

--- a/internal/interpreter/testdata/script-tests/remaining-kept-inorder.num.specs.json
+++ b/internal/interpreter/testdata/script-tests/remaining-kept-inorder.num.specs.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://raw.githubusercontent.com/formancehq/numscript/main/v1.specs.schema.json",
   "testCases": [
     {
       "it": "-",

--- a/internal/interpreter/testdata/script-tests/remaining-none-in-send-all.num.specs.json
+++ b/internal/interpreter/testdata/script-tests/remaining-none-in-send-all.num.specs.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://raw.githubusercontent.com/formancehq/numscript/main/v1.specs.schema.json",
   "testCases": [
     {
       "it": "-",

--- a/internal/interpreter/testdata/script-tests/remaining-none.num.specs.json
+++ b/internal/interpreter/testdata/script-tests/remaining-none.num.specs.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://raw.githubusercontent.com/formancehq/numscript/main/v1.specs.schema.json",
   "testCases": [
     {
       "it": "-",

--- a/internal/interpreter/testdata/script-tests/save/save-from-account__multi-postings.num.specs.json
+++ b/internal/interpreter/testdata/script-tests/save/save-from-account__multi-postings.num.specs.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://raw.githubusercontent.com/formancehq/numscript/main/v1.specs.schema.json",
   "testCases": [
     {
       "it": "-",

--- a/internal/interpreter/testdata/script-tests/save/save-from-account__save-a-different-asset.num.specs.json
+++ b/internal/interpreter/testdata/script-tests/save/save-from-account__save-a-different-asset.num.specs.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://raw.githubusercontent.com/formancehq/numscript/main/v1.specs.schema.json",
   "testCases": [
     {
       "it": "-",

--- a/internal/interpreter/testdata/script-tests/save/save-from-account__save-all-negative-balance.num.specs.json
+++ b/internal/interpreter/testdata/script-tests/save/save-from-account__save-all-negative-balance.num.specs.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://raw.githubusercontent.com/formancehq/numscript/main/v1.specs.schema.json",
   "testCases": [
     {
       "it": "-",

--- a/internal/interpreter/testdata/script-tests/save/save-from-account__save-all.num.specs.json
+++ b/internal/interpreter/testdata/script-tests/save/save-from-account__save-all.num.specs.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://raw.githubusercontent.com/formancehq/numscript/main/v1.specs.schema.json",
   "testCases": [
     {
       "it": "-",

--- a/internal/interpreter/testdata/script-tests/save/save-from-account__save-causes-failure.num.specs.json
+++ b/internal/interpreter/testdata/script-tests/save/save-from-account__save-causes-failure.num.specs.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://raw.githubusercontent.com/formancehq/numscript/main/v1.specs.schema.json",
   "testCases": [
     {
       "it": "-",

--- a/internal/interpreter/testdata/script-tests/save/save-from-account__save-more-than-balance.num.specs.json
+++ b/internal/interpreter/testdata/script-tests/save/save-from-account__save-more-than-balance.num.specs.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://raw.githubusercontent.com/formancehq/numscript/main/v1.specs.schema.json",
   "testCases": [
     {
       "it": "-",

--- a/internal/interpreter/testdata/script-tests/save/save-from-account__simple.num.specs.json
+++ b/internal/interpreter/testdata/script-tests/save/save-from-account__simple.num.specs.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://raw.githubusercontent.com/formancehq/numscript/main/v1.specs.schema.json",
   "testCases": [
     {
       "it": "-",

--- a/internal/interpreter/testdata/script-tests/save/save-from-account__with-asset-var.num.specs.json
+++ b/internal/interpreter/testdata/script-tests/save/save-from-account__with-asset-var.num.specs.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://raw.githubusercontent.com/formancehq/numscript/main/v1.specs.schema.json",
   "testCases": [
     {
       "it": "-",

--- a/internal/interpreter/testdata/script-tests/save/save-from-account__with-monetary-var.num.specs.json
+++ b/internal/interpreter/testdata/script-tests/save/save-from-account__with-monetary-var.num.specs.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://raw.githubusercontent.com/formancehq/numscript/main/v1.specs.schema.json",
   "testCases": [
     {
       "it": "-",

--- a/internal/interpreter/testdata/script-tests/send-all-destinatio-allot-complex.num.specs.json
+++ b/internal/interpreter/testdata/script-tests/send-all-destinatio-allot-complex.num.specs.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://raw.githubusercontent.com/formancehq/numscript/main/v1.specs.schema.json",
   "testCases": [
     {
       "it": "-",

--- a/internal/interpreter/testdata/script-tests/send-all-destinatio-allot.num.specs.json
+++ b/internal/interpreter/testdata/script-tests/send-all-destinatio-allot.num.specs.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://raw.githubusercontent.com/formancehq/numscript/main/v1.specs.schema.json",
   "testCases": [
     {
       "it": "-",

--- a/internal/interpreter/testdata/script-tests/send-all-many-max-in-dest.num.specs.json
+++ b/internal/interpreter/testdata/script-tests/send-all-many-max-in-dest.num.specs.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://raw.githubusercontent.com/formancehq/numscript/main/v1.specs.schema.json",
   "testCases": [
     {
       "it": "-",

--- a/internal/interpreter/testdata/script-tests/send-all-multi.num.specs.json
+++ b/internal/interpreter/testdata/script-tests/send-all-multi.num.specs.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://raw.githubusercontent.com/formancehq/numscript/main/v1.specs.schema.json",
   "testCases": [
     {
       "it": "-",

--- a/internal/interpreter/testdata/script-tests/send-all-variable.num.specs.json
+++ b/internal/interpreter/testdata/script-tests/send-all-variable.num.specs.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://raw.githubusercontent.com/formancehq/numscript/main/v1.specs.schema.json",
   "testCases": [
     {
       "it": "-",

--- a/internal/interpreter/testdata/script-tests/send-all-when-negative-with-overdraft.num.specs.json
+++ b/internal/interpreter/testdata/script-tests/send-all-when-negative-with-overdraft.num.specs.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://raw.githubusercontent.com/formancehq/numscript/main/v1.specs.schema.json",
   "testCases": [
     {
       "it": "-",

--- a/internal/interpreter/testdata/script-tests/send-all-when-negative.num.specs.json
+++ b/internal/interpreter/testdata/script-tests/send-all-when-negative.num.specs.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://raw.githubusercontent.com/formancehq/numscript/main/v1.specs.schema.json",
   "testCases": [
     {
       "it": "-",
@@ -8,8 +9,7 @@
           "asset": "USD/2",
           "amount": -100
         }
-      ],
-      "expect.postings": []
+      ]
     }
   ]
 }

--- a/internal/interpreter/testdata/script-tests/send-all.num.specs.json
+++ b/internal/interpreter/testdata/script-tests/send-all.num.specs.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://raw.githubusercontent.com/formancehq/numscript/main/v1.specs.schema.json",
   "testCases": [
     {
       "it": "-",

--- a/internal/interpreter/testdata/script-tests/send-allt-max-in-dest.num.specs.json
+++ b/internal/interpreter/testdata/script-tests/send-allt-max-in-dest.num.specs.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://raw.githubusercontent.com/formancehq/numscript/main/v1.specs.schema.json",
   "testCases": [
     {
       "it": "-",

--- a/internal/interpreter/testdata/script-tests/send-allt-max-in-src.num.specs.json
+++ b/internal/interpreter/testdata/script-tests/send-allt-max-in-src.num.specs.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://raw.githubusercontent.com/formancehq/numscript/main/v1.specs.schema.json",
   "testCases": [
     {
       "it": "-",

--- a/internal/interpreter/testdata/script-tests/send-allt-max-when-no-amount.num.specs.json
+++ b/internal/interpreter/testdata/script-tests/send-allt-max-when-no-amount.num.specs.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://raw.githubusercontent.com/formancehq/numscript/main/v1.specs.schema.json",
   "testCases": [
     {
       "it": "-",
@@ -8,8 +9,7 @@
           "asset": "USD/2",
           "amount": 0
         }
-      ],
-      "expect.postings": []
+      ]
     }
   ]
 }

--- a/internal/interpreter/testdata/script-tests/send-when-negative-balance.num.specs.json
+++ b/internal/interpreter/testdata/script-tests/send-when-negative-balance.num.specs.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://raw.githubusercontent.com/formancehq/numscript/main/v1.specs.schema.json",
   "testCases": [
     {
       "it": "-",

--- a/internal/interpreter/testdata/script-tests/send-zero.num.specs.json
+++ b/internal/interpreter/testdata/script-tests/send-zero.num.specs.json
@@ -1,9 +1,8 @@
 {
+  "$schema": "https://raw.githubusercontent.com/formancehq/numscript/main/v1.specs.schema.json",
   "testCases": [
     {
-      "it": "-",
-      "balances": [],
-      "expect.postings": []
+      "it": "-"
     }
   ]
 }

--- a/internal/interpreter/testdata/script-tests/send.num.specs.json
+++ b/internal/interpreter/testdata/script-tests/send.num.specs.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://raw.githubusercontent.com/formancehq/numscript/main/v1.specs.schema.json",
   "testCases": [
     {
       "it": "-",

--- a/internal/interpreter/testdata/script-tests/set-account-meta.num.specs.json
+++ b/internal/interpreter/testdata/script-tests/set-account-meta.num.specs.json
@@ -3,12 +3,12 @@
     {
       "it": "-",
       "expect.metadata": [
-        { "account": "acc", "key": "account", "value": { "type": "account", "name": "acc" } },
-        { "account": "acc", "key": "asset", "value": { "type": "asset", "name": "COIN" } },
-        { "account": "acc", "key": "num", "value": { "type": "number", "value": "42" } },
-        { "account": "acc", "key": "portion", "value": { "type": "portion", "numerator": "2", "denominator": "7" } },
-        { "account": "acc", "key": "portion-perc", "value": { "type": "portion", "numerator": "1", "denominator": "100" } },
-        { "account": "acc", "key": "str", "value": { "type": "string", "value": "abc" } }
+        { "account": "acc", "key": "account", "value": "acc" },
+        { "account": "acc", "key": "asset", "value": "COIN" },
+        { "account": "acc", "key": "num", "value": "42" },
+        { "account": "acc", "key": "portion", "value": "2/7" },
+        { "account": "acc", "key": "portion-perc", "value": "1/100" },
+        { "account": "acc", "key": "str", "value": "abc" }
       ]
     }
   ]

--- a/internal/interpreter/testdata/script-tests/set-account-meta.num.specs.json
+++ b/internal/interpreter/testdata/script-tests/set-account-meta.num.specs.json
@@ -1,14 +1,39 @@
 {
+  "$schema": "https://raw.githubusercontent.com/formancehq/numscript/main/v1.specs.schema.json",
   "testCases": [
     {
       "it": "-",
       "expect.metadata": [
-        { "account": "acc", "key": "account", "value": "acc" },
-        { "account": "acc", "key": "asset", "value": "COIN" },
-        { "account": "acc", "key": "num", "value": "42" },
-        { "account": "acc", "key": "portion", "value": "2/7" },
-        { "account": "acc", "key": "portion-perc", "value": "1/100" },
-        { "account": "acc", "key": "str", "value": "abc" }
+        {
+          "account": "acc",
+          "key": "account",
+          "value": "acc"
+        },
+        {
+          "account": "acc",
+          "key": "asset",
+          "value": "COIN"
+        },
+        {
+          "account": "acc",
+          "key": "num",
+          "value": "42"
+        },
+        {
+          "account": "acc",
+          "key": "portion",
+          "value": "2/7"
+        },
+        {
+          "account": "acc",
+          "key": "portion-perc",
+          "value": "1/100"
+        },
+        {
+          "account": "acc",
+          "key": "str",
+          "value": "abc"
+        }
       ]
     }
   ]

--- a/internal/interpreter/testdata/script-tests/set-tx-meta.num.specs.json
+++ b/internal/interpreter/testdata/script-tests/set-tx-meta.num.specs.json
@@ -1,13 +1,29 @@
 {
+  "$schema": "https://raw.githubusercontent.com/formancehq/numscript/main/v1.specs.schema.json",
   "testCases": [
     {
       "it": "-",
       "expect.txMetadata": [
-        { "key": "account", "value": "acc" },
-        { "key": "asset", "value": "COIN" },
-        { "key": "num", "value": "42" },
-        { "key": "portion", "value": "3/25" },
-        { "key": "str", "value": "abc" }
+        {
+          "key": "num",
+          "value": "42"
+        },
+        {
+          "key": "str",
+          "value": "abc"
+        },
+        {
+          "key": "asset",
+          "value": "COIN"
+        },
+        {
+          "key": "account",
+          "value": "acc"
+        },
+        {
+          "key": "portion",
+          "value": "3/25"
+        }
       ]
     }
   ]

--- a/internal/interpreter/testdata/script-tests/set-tx-meta.num.specs.json
+++ b/internal/interpreter/testdata/script-tests/set-tx-meta.num.specs.json
@@ -3,11 +3,11 @@
     {
       "it": "-",
       "expect.txMetadata": [
-        { "key": "account", "value": { "type": "account", "name": "acc" } },
-        { "key": "asset", "value": { "type": "asset", "name": "COIN" } },
-        { "key": "num", "value": { "type": "number", "value": "42" } },
-        { "key": "portion", "value": { "type": "portion", "numerator": "3", "denominator": "25" } },
-        { "key": "str", "value": { "type": "string", "value": "abc" } }
+        { "key": "account", "value": "acc" },
+        { "key": "asset", "value": "COIN" },
+        { "key": "num", "value": "42" },
+        { "key": "portion", "value": "3/25" },
+        { "key": "str", "value": "abc" }
       ]
     }
   ]

--- a/internal/interpreter/testdata/script-tests/source-allotment-invalid-amt.num.specs.json
+++ b/internal/interpreter/testdata/script-tests/source-allotment-invalid-amt.num.specs.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://raw.githubusercontent.com/formancehq/numscript/main/v1.specs.schema.json",
   "testCases": [
     {
       "it": "-",

--- a/internal/interpreter/testdata/script-tests/source-allotment.num.specs.json
+++ b/internal/interpreter/testdata/script-tests/source-allotment.num.specs.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://raw.githubusercontent.com/formancehq/numscript/main/v1.specs.schema.json",
   "testCases": [
     {
       "it": "-",

--- a/internal/interpreter/testdata/script-tests/source-complex.num.specs.json
+++ b/internal/interpreter/testdata/script-tests/source-complex.num.specs.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://raw.githubusercontent.com/formancehq/numscript/main/v1.specs.schema.json",
   "testCases": [
     {
       "it": "-",

--- a/internal/interpreter/testdata/script-tests/source-overlapping.num.specs.json
+++ b/internal/interpreter/testdata/script-tests/source-overlapping.num.specs.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://raw.githubusercontent.com/formancehq/numscript/main/v1.specs.schema.json",
   "testCases": [
     {
       "it": "-",

--- a/internal/interpreter/testdata/script-tests/source.num.specs.json
+++ b/internal/interpreter/testdata/script-tests/source.num.specs.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://raw.githubusercontent.com/formancehq/numscript/main/v1.specs.schema.json",
   "testCases": [
     {
       "it": "-",

--- a/internal/interpreter/testdata/script-tests/sub-monetaries.num.specs.json
+++ b/internal/interpreter/testdata/script-tests/sub-monetaries.num.specs.json
@@ -3,7 +3,7 @@
     {
       "it": "-",
       "expect.txMetadata": [
-        { "key": "k", "value": { "type": "monetary", "asset": "USD/2", "amount": "7" } }
+        { "key": "k", "value": "USD/2 7" }
       ]
     }
   ]

--- a/internal/interpreter/testdata/script-tests/sub-monetaries.num.specs.json
+++ b/internal/interpreter/testdata/script-tests/sub-monetaries.num.specs.json
@@ -1,9 +1,13 @@
 {
+  "$schema": "https://raw.githubusercontent.com/formancehq/numscript/main/v1.specs.schema.json",
   "testCases": [
     {
       "it": "-",
       "expect.txMetadata": [
-        { "key": "k", "value": "USD/2 7" }
+        {
+          "key": "k",
+          "value": "USD/2 7"
+        }
       ]
     }
   ]

--- a/internal/interpreter/testdata/script-tests/sub-numbers.num.specs.json
+++ b/internal/interpreter/testdata/script-tests/sub-numbers.num.specs.json
@@ -1,9 +1,13 @@
 {
+  "$schema": "https://raw.githubusercontent.com/formancehq/numscript/main/v1.specs.schema.json",
   "testCases": [
     {
       "it": "-",
       "expect.txMetadata": [
-        { "key": "k", "value": "9" }
+        {
+          "key": "k",
+          "value": "9"
+        }
       ]
     }
   ]

--- a/internal/interpreter/testdata/script-tests/sub-numbers.num.specs.json
+++ b/internal/interpreter/testdata/script-tests/sub-numbers.num.specs.json
@@ -3,7 +3,7 @@
     {
       "it": "-",
       "expect.txMetadata": [
-        { "key": "k", "value": { "type": "number", "value": "9" } }
+        { "key": "k", "value": "9" }
       ]
     }
   ]

--- a/internal/interpreter/testdata/script-tests/track-balances-send-all.num.specs.json
+++ b/internal/interpreter/testdata/script-tests/track-balances-send-all.num.specs.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://raw.githubusercontent.com/formancehq/numscript/main/v1.specs.schema.json",
   "testCases": [
     {
       "it": "-",

--- a/internal/interpreter/testdata/script-tests/track-balances.num.specs.json
+++ b/internal/interpreter/testdata/script-tests/track-balances.num.specs.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://raw.githubusercontent.com/formancehq/numscript/main/v1.specs.schema.json",
   "testCases": [
     {
       "it": "-",

--- a/internal/interpreter/testdata/script-tests/track-balances2.num.specs.json
+++ b/internal/interpreter/testdata/script-tests/track-balances2.num.specs.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://raw.githubusercontent.com/formancehq/numscript/main/v1.specs.schema.json",
   "testCases": [
     {
       "it": "-",

--- a/internal/interpreter/testdata/script-tests/track-balances3.num.specs.json
+++ b/internal/interpreter/testdata/script-tests/track-balances3.num.specs.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://raw.githubusercontent.com/formancehq/numscript/main/v1.specs.schema.json",
   "testCases": [
     {
       "it": "-",

--- a/internal/interpreter/testdata/script-tests/unbounded-overdraft-when-not-enough-funds.num.specs.json
+++ b/internal/interpreter/testdata/script-tests/unbounded-overdraft-when-not-enough-funds.num.specs.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://raw.githubusercontent.com/formancehq/numscript/main/v1.specs.schema.json",
   "testCases": [
     {
       "it": "-",

--- a/internal/interpreter/testdata/script-tests/update-balances.num.specs.json
+++ b/internal/interpreter/testdata/script-tests/update-balances.num.specs.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://raw.githubusercontent.com/formancehq/numscript/main/v1.specs.schema.json",
   "testCases": [
     {
       "it": "-",

--- a/internal/interpreter/testdata/script-tests/use-balance-twice.num.specs.json
+++ b/internal/interpreter/testdata/script-tests/use-balance-twice.num.specs.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://raw.githubusercontent.com/formancehq/numscript/main/v1.specs.schema.json",
   "testCases": [
     {
       "it": "-",

--- a/internal/interpreter/testdata/script-tests/use-different-assets-with-same-source-account.num.specs.json
+++ b/internal/interpreter/testdata/script-tests/use-different-assets-with-same-source-account.num.specs.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://raw.githubusercontent.com/formancehq/numscript/main/v1.specs.schema.json",
   "testCases": [
     {
       "it": "-",

--- a/internal/interpreter/testdata/script-tests/variable-asset.num.specs.json
+++ b/internal/interpreter/testdata/script-tests/variable-asset.num.specs.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://raw.githubusercontent.com/formancehq/numscript/main/v1.specs.schema.json",
   "testCases": [
     {
       "it": "-",

--- a/internal/interpreter/testdata/script-tests/variable-balance__1.num.specs.json
+++ b/internal/interpreter/testdata/script-tests/variable-balance__1.num.specs.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://raw.githubusercontent.com/formancehq/numscript/main/v1.specs.schema.json",
   "testCases": [
     {
       "it": "-",

--- a/internal/interpreter/testdata/script-tests/variable-balance__2.num.specs.json
+++ b/internal/interpreter/testdata/script-tests/variable-balance__2.num.specs.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://raw.githubusercontent.com/formancehq/numscript/main/v1.specs.schema.json",
   "testCases": [
     {
       "it": "-",

--- a/internal/interpreter/testdata/script-tests/variable-balance__3.num.specs.json
+++ b/internal/interpreter/testdata/script-tests/variable-balance__3.num.specs.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://raw.githubusercontent.com/formancehq/numscript/main/v1.specs.schema.json",
   "testCases": [
     {
       "it": "-",

--- a/internal/interpreter/testdata/script-tests/variable-balance__4.num.specs.json
+++ b/internal/interpreter/testdata/script-tests/variable-balance__4.num.specs.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://raw.githubusercontent.com/formancehq/numscript/main/v1.specs.schema.json",
   "testCases": [
     {
       "it": "-",

--- a/internal/interpreter/testdata/script-tests/variable-balance__5.num.specs.json
+++ b/internal/interpreter/testdata/script-tests/variable-balance__5.num.specs.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://raw.githubusercontent.com/formancehq/numscript/main/v1.specs.schema.json",
   "testCases": [
     {
       "it": "-",

--- a/internal/interpreter/testdata/script-tests/variable-portion-part.num.specs.json
+++ b/internal/interpreter/testdata/script-tests/variable-portion-part.num.specs.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://raw.githubusercontent.com/formancehq/numscript/main/v1.specs.schema.json",
   "testCases": [
     {
       "it": "-",

--- a/internal/interpreter/testdata/script-tests/variables-json.num.specs.json
+++ b/internal/interpreter/testdata/script-tests/variables-json.num.specs.json
@@ -26,9 +26,9 @@
         }
       ],
       "expect.txMetadata": [
-        { "key": "description", "value": { "type": "string", "value": "midnight ride" } },
-        { "key": "por", "value": { "type": "portion", "numerator": "21", "denominator": "50" } },
-        { "key": "ride", "value": { "type": "number", "value": "1" } }
+        { "key": "description", "value": "midnight ride" },
+        { "key": "por", "value": "21/50" },
+        { "key": "ride", "value": "1" }
       ]
     }
   ]

--- a/internal/interpreter/testdata/script-tests/variables-json.num.specs.json
+++ b/internal/interpreter/testdata/script-tests/variables-json.num.specs.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://raw.githubusercontent.com/formancehq/numscript/main/v1.specs.schema.json",
   "testCases": [
     {
       "it": "-",
@@ -26,9 +27,18 @@
         }
       ],
       "expect.txMetadata": [
-        { "key": "description", "value": "midnight ride" },
-        { "key": "por", "value": "21/50" },
-        { "key": "ride", "value": "1" }
+        {
+          "key": "description",
+          "value": "midnight ride"
+        },
+        {
+          "key": "ride",
+          "value": "1"
+        },
+        {
+          "key": "por",
+          "value": "21/50"
+        }
       ]
     }
   ]

--- a/internal/interpreter/testdata/script-tests/variables.num.specs.json
+++ b/internal/interpreter/testdata/script-tests/variables.num.specs.json
@@ -25,8 +25,8 @@
         }
       ],
       "expect.txMetadata": [
-        { "key": "description", "value": { "type": "string", "value": "midnight ride" } },
-        { "key": "ride", "value": { "type": "number", "value": "1" } }
+        { "key": "description", "value": "midnight ride" },
+        { "key": "ride", "value": "1" }
       ]
     }
   ]

--- a/internal/interpreter/testdata/script-tests/variables.num.specs.json
+++ b/internal/interpreter/testdata/script-tests/variables.num.specs.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://raw.githubusercontent.com/formancehq/numscript/main/v1.specs.schema.json",
   "testCases": [
     {
       "it": "-",
@@ -25,8 +26,14 @@
         }
       ],
       "expect.txMetadata": [
-        { "key": "description", "value": "midnight ride" },
-        { "key": "ride", "value": "1" }
+        {
+          "key": "description",
+          "value": "midnight ride"
+        },
+        {
+          "key": "ride",
+          "value": "1"
+        }
       ]
     }
   ]

--- a/internal/interpreter/testdata/script-tests/world-source.num.specs.json
+++ b/internal/interpreter/testdata/script-tests/world-source.num.specs.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://raw.githubusercontent.com/formancehq/numscript/main/v1.specs.schema.json",
   "testCases": [
     {
       "it": "-",

--- a/internal/interpreter/testdata/script-tests/zero-postings-destination.num.specs.json
+++ b/internal/interpreter/testdata/script-tests/zero-postings-destination.num.specs.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://raw.githubusercontent.com/formancehq/numscript/main/v1.specs.schema.json",
   "testCases": [
     {
       "it": "-",

--- a/internal/interpreter/testdata/script-tests/zero-postings-explicit-allotment.num.specs.json
+++ b/internal/interpreter/testdata/script-tests/zero-postings-explicit-allotment.num.specs.json
@@ -1,9 +1,8 @@
 {
+  "$schema": "https://raw.githubusercontent.com/formancehq/numscript/main/v1.specs.schema.json",
   "testCases": [
     {
-      "it": "-",
-      "balances": [],
-      "expect.postings": []
+      "it": "-"
     }
   ]
 }

--- a/internal/interpreter/testdata/script-tests/zero-postings-explicit-inorder.num.specs.json
+++ b/internal/interpreter/testdata/script-tests/zero-postings-explicit-inorder.num.specs.json
@@ -1,9 +1,8 @@
 {
+  "$schema": "https://raw.githubusercontent.com/formancehq/numscript/main/v1.specs.schema.json",
   "testCases": [
     {
-      "it": "-",
-      "balances": [],
-      "expect.postings": []
+      "it": "-"
     }
   ]
 }

--- a/internal/interpreter/testdata/script-tests/zero-postings.num.specs.json
+++ b/internal/interpreter/testdata/script-tests/zero-postings.num.specs.json
@@ -1,8 +1,8 @@
 {
+  "$schema": "https://raw.githubusercontent.com/formancehq/numscript/main/v1.specs.schema.json",
   "testCases": [
     {
       "it": "-",
-      "balances": [],
       "expect.postings": [
         {
           "source": "world",

--- a/internal/interpreter/value.go
+++ b/internal/interpreter/value.go
@@ -1,7 +1,6 @@
 package interpreter
 
 import (
-	"encoding/json"
 	"fmt"
 	"math/big"
 	"strconv"
@@ -55,169 +54,32 @@ func NewAsset(src string) (Asset, InterpreterError) {
 	return Asset(src), nil
 }
 
-// A Value is (de)serialized as a tagged-JSON discriminated union, keyed by
-// "type", so the on-wire form is type-explicit and unambiguous (e.g. the string
-// "42" and the number 42 are distinguishable), rather than stringly-typed:
+// MetaString renders v as it appears in the metadata wire format: the value
+// written the way it would be in source, with no added delimiters.
 //
-//	string   -> { "type": "string",   "value": "abc" }
-//	number   -> { "type": "number",   "value": "42" }
-//	asset    -> { "type": "asset",    "name": "COIN" }
-//	account  -> { "type": "account",  "name": "x", "scope": "s" }   // scope optional
-//	monetary -> { "type": "monetary", "asset": "COIN", "amount": "100" }
-//	portion  -> { "type": "portion",  "numerator": "1", "denominator": "2" }
-const (
-	valueTypeString   = "string"
-	valueTypeNumber   = "number"
-	valueTypeAsset    = "asset"
-	valueTypeAccount  = "account"
-	valueTypeMonetary = "monetary"
-	valueTypePortion  = "portion"
-)
-
-// The per-shape tagged-JSON structs below are each shared by their type's
-// MarshalJSON and by ParseTaggedValue, so the layout is defined once.
+// This is deliberately not String(). String() delimits values so a reader can
+// tell them apart — it quotes strings and writes accounts as @name — which suits
+// diagnostics. The metadata format is untyped: a value is stored as its rendered
+// text and assertions compare that text, so set_tx_meta("k", "42") and
+// set_tx_meta("k", 42) are indistinguishable there. That is the same behaviour
+// the format had before values were briefly tagged.
 //
-//	scalar (string/number) -> { "type": ..., "value": "..." }
-//	asset                  -> { "type": "asset",    "name": "COIN" }
-//	account                -> { "type": "account",  "name": "x", "scope": "s" }
-//	monetary               -> { "type": "monetary", "asset": "COIN", "amount": "100" }
-//	portion                -> { "type": "portion",  "numerator": "1", "denominator": "2" }
-type (
-	taggedScalar struct {
-		Type  string `json:"type"`
-		Value string `json:"value"`
-	}
-	taggedAsset struct {
-		Type string `json:"type"`
-		Name string `json:"name"`
-	}
-	taggedAccount struct {
-		Type  string `json:"type"`
-		Name  string `json:"name"`
-		Scope string `json:"scope,omitempty"`
-	}
-	taggedMonetary struct {
-		Type   string `json:"type"`
-		Asset  string `json:"asset"`
-		Amount string `json:"amount"`
-	}
-	taggedPortion struct {
-		Type        string `json:"type"`
-		Numerator   string `json:"numerator"`
-		Denominator string `json:"denominator"`
-	}
-)
-
-// ParseTaggedValue decodes the tagged-JSON representation of a Value. It reads
-// the "type" discriminator (json can't unmarshal directly into the Value
-// interface), then decodes into the struct shared with that type's MarshalJSON.
-func ParseTaggedValue(data []byte) (Value, error) {
-	var tag struct {
-		Type string `json:"type"`
-	}
-	if err := json.Unmarshal(data, &tag); err != nil {
-		return nil, err
-	}
-
-	switch tag.Type {
-	case valueTypeString:
-		var v taggedScalar
-		if err := json.Unmarshal(data, &v); err != nil {
-			return nil, err
-		}
-		return String(v.Value), nil
-
-	case valueTypeAccount:
-		var v taggedAccount
-		if err := json.Unmarshal(data, &v); err != nil {
-			return nil, err
-		}
-		if !checkAccountName(v.Name) {
-			return nil, fmt.Errorf("invalid account name: %q", v.Name)
-		}
-		if !checkScopeName(v.Scope) {
-			return nil, fmt.Errorf("invalid account scope: %q", v.Scope)
-		}
-		return AccountAddress{Name: v.Name, Scope: v.Scope}, nil
-
-	case valueTypeAsset:
-		var v taggedAsset
-		if err := json.Unmarshal(data, &v); err != nil {
-			return nil, err
-		}
-		return Asset(v.Name), nil
-
-	case valueTypeNumber:
-		var v taggedScalar
-		if err := json.Unmarshal(data, &v); err != nil {
-			return nil, err
-		}
-		n, ok := new(big.Int).SetString(v.Value, 10)
-		if !ok {
-			return nil, fmt.Errorf("invalid number value: %q", v.Value)
-		}
-		return MonetaryInt(*n), nil
-
-	case valueTypeMonetary:
-		var v taggedMonetary
-		if err := json.Unmarshal(data, &v); err != nil {
-			return nil, err
-		}
-		n, ok := new(big.Int).SetString(v.Amount, 10)
-		if !ok {
-			return nil, fmt.Errorf("invalid monetary amount: %q", v.Amount)
-		}
-		return Monetary{Asset: Asset(v.Asset), Amount: MonetaryInt(*n)}, nil
-
-	case valueTypePortion:
-		var v taggedPortion
-		if err := json.Unmarshal(data, &v); err != nil {
-			return nil, err
-		}
-		num, ok := new(big.Int).SetString(v.Numerator, 10)
-		if !ok {
-			return nil, fmt.Errorf("invalid portion numerator: %q", v.Numerator)
-		}
-		denom, ok := new(big.Int).SetString(v.Denominator, 10)
-		if !ok {
-			return nil, fmt.Errorf("invalid portion denominator: %q", v.Denominator)
-		}
-		if denom.Sign() == 0 {
-			return nil, fmt.Errorf("invalid portion: zero denominator")
-		}
-		return Portion(*new(big.Rat).SetFrac(num, denom)), nil
-
-	case "":
-		return nil, fmt.Errorf("missing value type")
+// An account value is rendered as its bare name. Nothing is lost: a scoped
+// account cannot reach metadata at all, since setTxMeta and setAccountMeta both
+// reject one via rejectScopedAccountMeta.
+func MetaString(v Value) string {
+	switch v := v.(type) {
+	case String:
+		return string(v)
+	case AccountAddress:
+		return v.Name
+	case Asset:
+		return string(v)
 	default:
-		return nil, fmt.Errorf("unknown value type: %q", tag.Type)
+		// the remaining types (MonetaryInt, Monetary, Portion) already render
+		// without delimiters
+		return v.String()
 	}
-}
-
-func (v String) MarshalJSON() ([]byte, error) {
-	return json.Marshal(taggedScalar{valueTypeString, string(v)})
-}
-
-func (v Asset) MarshalJSON() ([]byte, error) {
-	return json.Marshal(taggedAsset{valueTypeAsset, string(v)})
-}
-
-func (v AccountAddress) MarshalJSON() ([]byte, error) {
-	return json.Marshal(taggedAccount{valueTypeAccount, v.Name, v.Scope})
-}
-
-func (v MonetaryInt) MarshalJSON() ([]byte, error) {
-	bi := big.Int(v)
-	return json.Marshal(taggedScalar{valueTypeNumber, bi.String()})
-}
-
-func (v Portion) MarshalJSON() ([]byte, error) {
-	r := big.Rat(v)
-	return json.Marshal(taggedPortion{valueTypePortion, r.Num().String(), r.Denom().String()})
-}
-
-func (v Monetary) MarshalJSON() ([]byte, error) {
-	return json.Marshal(taggedMonetary{valueTypeMonetary, string(v.Asset), v.Amount.String()})
 }
 
 func (v String) String() string {

--- a/internal/interpreter/value.go
+++ b/internal/interpreter/value.go
@@ -55,23 +55,26 @@ func NewAsset(src string) (Asset, InterpreterError) {
 }
 
 // MetaString renders v as it appears in the metadata wire format: the value
-// written the way it would be in source, with no added delimiters.
+// written the way it would be in source, with no added delimiters. This is
+// deliberately not String(): String() delimits values so a reader can tell
+// them apart (it quotes strings and writes accounts as @name), which suits
+// diagnostics, but the metadata format is untyped by design — a value is
+// stored as its rendered text and compared as that text, so e.g.
+// set_tx_meta("k", "42") and set_tx_meta("k", 42) are indistinguishable here.
 //
-// This is deliberately not String(). String() delimits values so a reader can
-// tell them apart — it quotes strings and writes accounts as @name — which suits
-// diagnostics. The metadata format is untyped: a value is stored as its rendered
-// text and assertions compare that text, so set_tx_meta("k", "42") and
-// set_tx_meta("k", 42) are indistinguishable there. That is the same behaviour
-// the format had before values were briefly tagged.
-//
-// An account value is rendered as its bare name. Nothing is lost: a scoped
-// account cannot reach metadata at all, since setTxMeta and setAccountMeta both
-// reject one via rejectScopedAccountMeta.
+// An account value is rendered as its bare name, dropping any scope. Nothing
+// is lost in practice: a scoped account cannot reach metadata at all, since
+// setTxMeta and setAccountMeta both reject one via rejectScopedAccountMeta —
+// the panic below is a last-resort check on that invariant, not a real error
+// path.
 func MetaString(v Value) string {
 	switch v := v.(type) {
 	case String:
 		return string(v)
 	case AccountAddress:
+		if v.Scope != "" {
+			panic(fmt.Sprintf("MetaString: unexpected scoped account in metadata: %q (scope %q)", v.Name, v.Scope))
+		}
 		return v.Name
 	case Asset:
 		return string(v)

--- a/internal/interpreter/value_test.go
+++ b/internal/interpreter/value_test.go
@@ -1,7 +1,6 @@
 package interpreter_test
 
 import (
-	"encoding/json"
 	"math/big"
 	"testing"
 
@@ -10,98 +9,63 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestMarshalMonetaryInt(t *testing.T) {
+func TestMetaString(t *testing.T) {
 	t.Parallel()
 
-	x := interpreter.NewMonetaryInt(42)
-
-	j, err := json.Marshal(x)
-	require.Nil(t, err)
-	require.JSONEq(t, `{"type":"number","value":"42"}`, string(j))
-}
-
-func TestMarshalString(t *testing.T) {
-	t.Parallel()
-
-	x := interpreter.String("abc")
-
-	j, err := json.Marshal(x)
-	require.Nil(t, err)
-	require.JSONEq(t, `{"type":"string","value":"abc"}`, string(j))
-}
-
-func TestMarshalAsset(t *testing.T) {
-	t.Parallel()
-
-	x := interpreter.Asset("EUR/2")
-
-	j, err := json.Marshal(x)
-	require.Nil(t, err)
-	require.JSONEq(t, `{"type":"asset","name":"EUR/2"}`, string(j))
-}
-
-func TestMarshalAddress(t *testing.T) {
-	t.Parallel()
-
-	j, err := json.Marshal(interpreter.AccountAddress{Name: "abc"})
-	require.Nil(t, err)
-	require.JSONEq(t, `{"type":"account","name":"abc"}`, string(j))
-
-	j, err = json.Marshal(interpreter.AccountAddress{Name: "abc", Scope: "s"})
-	require.Nil(t, err)
-	require.JSONEq(t, `{"type":"account","name":"abc","scope":"s"}`, string(j))
-}
-
-func TestMarshalPortion(t *testing.T) {
-	t.Parallel()
-
-	x := interpreter.Portion(*big.NewRat(2, 3))
-
-	j, err := json.Marshal(x)
-	require.Nil(t, err)
-	require.JSONEq(t, `{"type":"portion","numerator":"2","denominator":"3"}`, string(j))
-}
-
-func TestMarshalMonetary(t *testing.T) {
-	t.Parallel()
-
-	x := interpreter.Monetary{
-		Asset:  interpreter.Asset("USD/2"),
-		Amount: interpreter.NewMonetaryInt(100),
-	}
-
-	j, err := json.Marshal(x)
-	require.Nil(t, err)
-	require.JSONEq(t, `{"type":"monetary","asset":"USD/2","amount":"100"}`, string(j))
-}
-
-func TestParseTaggedValueRoundTrip(t *testing.T) {
-	t.Parallel()
-
-	values := []interpreter.Value{
-		interpreter.String("abc"),
-		interpreter.Asset("EUR/2"),
-		interpreter.AccountAddress{Name: "alice"},
-		interpreter.AccountAddress{Name: "alice", Scope: "reserve"},
-		interpreter.NewMonetaryInt(42),
-		interpreter.Monetary{Asset: "USD/2", Amount: interpreter.NewMonetaryInt(100)},
-		interpreter.Portion(*big.NewRat(2, 3)),
-	}
-
-	for _, v := range values {
-		j, err := json.Marshal(v)
-		require.Nil(t, err)
-
-		parsed, err := interpreter.ParseTaggedValue(j)
-		require.Nil(t, err)
-		// compare on the canonical source form
-		require.Equal(t, v.String(), parsed.String())
+	for _, tc := range []struct {
+		name     string
+		value    interpreter.Value
+		expected string
+	}{
+		{"string is not quoted", interpreter.String("abc"), "abc"},
+		{"empty string", interpreter.String(""), ""},
+		{"a string that looks like a number", interpreter.String("42"), "42"},
+		{"asset", interpreter.Asset("EUR/2"), "EUR/2"},
+		{"account has no @ prefix", interpreter.AccountAddress{Name: "alice"}, "alice"},
+		{"number", interpreter.NewMonetaryInt(42), "42"},
+		{"negative number", interpreter.NewMonetaryInt(-7), "-7"},
+		{"monetary", interpreter.Monetary{Asset: "USD/2", Amount: interpreter.NewMonetaryInt(100)}, "USD/2 100"},
+		{"portion", interpreter.Portion(*big.NewRat(2, 3)), "2/3"},
+		{"portion is normalized", interpreter.Portion(*big.NewRat(2, 4)), "1/2"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tc.expected, interpreter.MetaString(tc.value))
+		})
 	}
 }
 
-func TestParseTaggedValueRejectsUnknownType(t *testing.T) {
+// The metadata format is untyped on purpose: it stores the rendered value, so
+// values of different types that render the same are indistinguishable there.
+// This is the trade-off that keeps the format stringly-typed, and it is what the
+// pre-tagged format did too.
+func TestMetaStringConflatesTypesThatRenderAlike(t *testing.T) {
 	t.Parallel()
 
-	_, err := interpreter.ParseTaggedValue([]byte(`{"type":"bogus"}`))
-	require.Error(t, err)
+	require.Equal(t,
+		interpreter.MetaString(interpreter.String("42")),
+		interpreter.MetaString(interpreter.NewMonetaryInt(42)),
+	)
+
+	require.Equal(t,
+		interpreter.MetaString(interpreter.String("COIN")),
+		interpreter.MetaString(interpreter.Asset("COIN")),
+	)
+
+	require.Equal(t,
+		interpreter.MetaString(interpreter.String("alice")),
+		interpreter.MetaString(interpreter.AccountAddress{Name: "alice"}),
+	)
+}
+
+// String() is the diagnostic form and stays delimited, so error messages can
+// still tell a string from an account. MetaString is the wire form.
+func TestStringDiffersFromMetaString(t *testing.T) {
+	t.Parallel()
+
+	require.Equal(t, `"abc"`, interpreter.String("abc").String())
+	require.Equal(t, "abc", interpreter.MetaString(interpreter.String("abc")))
+
+	require.Equal(t, "@alice", interpreter.AccountAddress{Name: "alice"}.String())
+	require.Equal(t, "alice", interpreter.MetaString(interpreter.AccountAddress{Name: "alice"}))
 }

--- a/internal/specs_format/index.go
+++ b/internal/specs_format/index.go
@@ -2,7 +2,6 @@ package specs_format
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"math/big"
 	"reflect"
@@ -14,46 +13,25 @@ import (
 )
 
 // TxMetadataRow is a single transaction metadata entry. Like SetAccountMetadataRow,
-// the value's type is known, so it is carried as a typed Value written in the tagged
-// value format (e.g. {"type":"account","name":"x"}).
+// the value is the rendered text produced by interpreter.MetaString: the wire
+// format is untyped.
 type TxMetadataRow struct {
-	Key   string            `json:"key"`
-	Value interpreter.Value `json:"value"`
+	Key   string `json:"key"`
+	Value string `json:"value"`
 }
 
 // ExpectedTxMeta is a test case's expected transaction metadata: a list of rows,
 // mirroring expect.metadata. Comparison ignores order (see compareTxMeta).
 type ExpectedTxMeta []TxMetadataRow
 
-func (r *TxMetadataRow) UnmarshalJSON(data []byte) error {
-	var raw struct {
-		Key   string          `json:"key"`
-		Value json.RawMessage `json:"value"`
-	}
-	if err := json.Unmarshal(data, &raw); err != nil {
-		return err
-	}
-	value, err := interpreter.ParseTaggedValue(raw.Value)
-	if err != nil {
-		return err
-	}
-	r.Key, r.Value = raw.Key, value
-	return nil
-}
-
 // compareTxMeta reports whether two lists hold the same rows, ignoring order but
-// respecting multiplicity (so [x, x] != [x, y]). Values are compared on their
-// canonical source form, so a string "42" and the number 42 are not conflated.
+// respecting multiplicity (so [x, x] != [x, y]).
 func compareTxMeta(a ExpectedTxMeta, b ExpectedTxMeta) bool {
 	if len(a) != len(b) {
 		return false
 	}
 	key := func(r TxMetadataRow) string {
-		value := ""
-		if r.Value != nil {
-			value = r.Value.String()
-		}
-		return r.Key + "\x00" + value
+		return r.Key + "\x00" + r.Value
 	}
 	counts := make(map[string]int, len(a))
 	for _, r := range a {
@@ -78,6 +56,13 @@ func txMetaToRows(m interpreter.Metadata) ExpectedTxMeta {
 	}
 	return rows
 }
+
+// SchemaURL is the canonical $schema of the current specs format. Generated
+// files point at it, and it is what a migration rewrites a stale $schema to.
+const SchemaURL = "https://raw.githubusercontent.com/formancehq/numscript/main/v1.specs.schema.json"
+
+// InputsSchemaURL is the equivalent for the inputs format.
+const InputsSchemaURL = "https://raw.githubusercontent.com/formancehq/numscript/main/v1.inputs.schema.json"
 
 // --- Specs:
 type Specs struct {

--- a/internal/specs_format/migrate.go
+++ b/internal/specs_format/migrate.go
@@ -1,0 +1,39 @@
+package specs_format
+
+import (
+	"encoding/json"
+	"strings"
+)
+
+// MigrateSpecsContent rewrites a specs file's raw JSON to the current format:
+// a missing or non-canonical $schema is pointed at SchemaURL. It reports
+// whether anything changed, so a caller can gate writing the result behind a
+// flag while still surfacing that a file is stale.
+//
+// Staleness is detected structurally (just the $schema field), not by
+// comparing byte-for-byte against a canonical re-marshal — otherwise a file
+// that is already current, just formatted differently (e.g. one row per
+// line), would be falsely flagged. Once a file IS stale, though, the rewrite
+// re-marshals the whole struct, so it also canonicalizes formatting to match
+// what the rest of the CLI generates (e.g. test-init) — this is not a
+// minimal-diff patch.
+func MigrateSpecsContent(raw []byte) (out []byte, changed bool, err error) {
+	var specs Specs
+	if err := json.Unmarshal(raw, &specs); err != nil {
+		return nil, false, err
+	}
+
+	if strings.HasSuffix(specs.Schema, "/v1.specs.schema.json") {
+		return raw, false, nil
+	}
+
+	specs.Schema = SchemaURL
+
+	marshaled, err := json.MarshalIndent(specs, "", "  ")
+	if err != nil {
+		return nil, false, err
+	}
+	marshaled = append(marshaled, '\n')
+
+	return marshaled, true, nil
+}

--- a/internal/specs_format/migrate.go
+++ b/internal/specs_format/migrate.go
@@ -6,24 +6,26 @@ import (
 )
 
 // MigrateSpecsContent rewrites a specs file's raw JSON to the current format:
-// a missing or non-canonical $schema is pointed at SchemaURL. It reports
-// whether anything changed, so a caller can gate writing the result behind a
-// flag while still surfacing that a file is stale.
+// v0.0.24's nested-map balances/metadata are flattened to today's row arrays
+// (see migrate_v0024.go), and a missing or non-canonical $schema is pointed
+// at SchemaURL. It reports whether anything changed, so a caller can gate
+// writing the result behind a flag while still surfacing that a file is
+// stale.
 //
-// Staleness is detected structurally (just the $schema field), not by
-// comparing byte-for-byte against a canonical re-marshal — otherwise a file
-// that is already current, just formatted differently (e.g. one row per
-// line), would be falsely flagged. Once a file IS stale, though, the rewrite
-// re-marshals the whole struct, so it also canonicalizes formatting to match
-// what the rest of the CLI generates (e.g. test-init) — this is not a
-// minimal-diff patch.
+// $schema staleness is detected structurally, not by comparing byte-for-byte
+// against a canonical re-marshal — otherwise a file that is already current,
+// just formatted differently (e.g. one row per line), would be falsely
+// flagged. Once a file IS stale, though, the rewrite re-marshals the whole
+// struct, so it also canonicalizes formatting to match what the rest of the
+// CLI generates (e.g. test-init) — this is not a minimal-diff patch.
 func MigrateSpecsContent(raw []byte) (out []byte, changed bool, err error) {
-	var specs Specs
-	if err := json.Unmarshal(raw, &specs); err != nil {
+	specs, structureChanged, err := parseSpecsForMigration(raw)
+	if err != nil {
 		return nil, false, err
 	}
 
-	if strings.HasSuffix(specs.Schema, "/v1.specs.schema.json") {
+	schemaStale := !strings.HasSuffix(specs.Schema, "/v1.specs.schema.json")
+	if !schemaStale && !structureChanged {
 		return raw, false, nil
 	}
 
@@ -36,4 +38,24 @@ func MigrateSpecsContent(raw []byte) (out []byte, changed bool, err error) {
 	marshaled = append(marshaled, '\n')
 
 	return marshaled, true, nil
+}
+
+// parseSpecsForMigration parses raw as the current Specs shape, falling back
+// to the v0.0.24 shape (see migrate_v0024.go) if that fails. It reports
+// whether the fallback was used, i.e. whether the file's structure (not just
+// its $schema) needed upgrading.
+func parseSpecsForMigration(raw []byte) (specs Specs, structureChanged bool, err error) {
+	if err := json.Unmarshal(raw, &specs); err == nil {
+		return specs, false, nil
+	}
+
+	legacy, ok := parseLegacyV0024Specs(raw)
+	if !ok {
+		// Re-parse to surface the current shape's error: it applies to more
+		// specs files (v0.0.24 was never the only released shape a file could
+		// predate) and is what the rest of the CLI's error output expects.
+		return Specs{}, false, json.Unmarshal(raw, &specs)
+	}
+
+	return upgradeLegacyV0024Specs(legacy), true, nil
 }

--- a/internal/specs_format/migrate.go
+++ b/internal/specs_format/migrate.go
@@ -2,30 +2,30 @@ package specs_format
 
 import (
 	"encoding/json"
-	"strings"
 )
 
 // MigrateSpecsContent rewrites a specs file's raw JSON to the current format:
 // v0.0.24's nested-map balances/metadata are flattened to today's row arrays
-// (see migrate_v0024.go), and a missing or non-canonical $schema is pointed
-// at SchemaURL. It reports whether anything changed, so a caller can gate
-// writing the result behind a flag while still surfacing that a file is
+// (see migrate_v0024.go). It reports whether anything changed, so a caller can
+// gate writing the result behind a flag while still surfacing that a file is
 // stale.
 //
-// $schema staleness is detected structurally, not by comparing byte-for-byte
-// against a canonical re-marshal — otherwise a file that is already current,
-// just formatted differently (e.g. one row per line), would be falsely
-// flagged. Once a file IS stale, though, the rewrite re-marshals the whole
-// struct, so it also canonicalizes formatting to match what the rest of the
-// CLI generates (e.g. test-init) — this is not a minimal-diff patch.
+// Staleness is decided by structure alone: $schema is an editor hint, not part
+// of the format, and nothing in the CLI reads it to parse, validate or
+// dispatch. A file's shape is what says which format it is, and
+// parseSpecsForMigration already determines that by parsing. A migrated file
+// does get its $schema pointed at SchemaURL, since its shape really did change.
+//
+// Once a file IS stale, the rewrite re-marshals the whole struct, so it also
+// canonicalizes formatting to match what the rest of the CLI generates (e.g.
+// test-init) — this is not a minimal-diff patch.
 func MigrateSpecsContent(raw []byte) (out []byte, changed bool, err error) {
 	specs, structureChanged, err := parseSpecsForMigration(raw)
 	if err != nil {
 		return nil, false, err
 	}
 
-	schemaStale := !strings.HasSuffix(specs.Schema, "/v1.specs.schema.json")
-	if !schemaStale && !structureChanged {
+	if !structureChanged {
 		return raw, false, nil
 	}
 
@@ -42,8 +42,8 @@ func MigrateSpecsContent(raw []byte) (out []byte, changed bool, err error) {
 
 // parseSpecsForMigration parses raw as the current Specs shape, falling back
 // to the v0.0.24 shape (see migrate_v0024.go) if that fails. It reports
-// whether the fallback was used, i.e. whether the file's structure (not just
-// its $schema) needed upgrading.
+// whether the fallback was used, i.e. whether the file's structure needed
+// upgrading.
 func parseSpecsForMigration(raw []byte) (specs Specs, structureChanged bool, err error) {
 	if err := json.Unmarshal(raw, &specs); err == nil {
 		return specs, false, nil

--- a/internal/specs_format/migrate.go
+++ b/internal/specs_format/migrate.go
@@ -4,17 +4,25 @@ import (
 	"encoding/json"
 )
 
-// MigrateSpecsContent rewrites a specs file's raw JSON to the current format:
-// v0.0.24's nested-map balances/metadata are flattened to today's row arrays
-// (see migrate_v0024.go). It reports whether anything changed, so a caller can
-// gate writing the result behind a flag while still surfacing that a file is
-// stale.
+// MigrateSpecsContent rewrites a specs file's raw JSON to the current format.
+// Two things can be outdated, independently of each other:
 //
-// Staleness is decided by structure alone: $schema is an editor hint, not part
-// of the format, and nothing in the CLI reads it to parse, validate or
-// dispatch. A file's shape is what says which format it is, and
-// parseSpecsForMigration already determines that by parsing. A migrated file
-// does get its $schema pointed at SchemaURL, since its shape really did change.
+//   - the file's structure: v0.0.24's nested-map balances/metadata are
+//     flattened to today's row arrays (see migrate_v0024.go);
+//   - its asset names: v0.0.24's ASSET_COLOR encoding is split back into the
+//     separate asset/color fields (see decodeLegacyColors).
+//
+// The second can be stale on its own, since the encoding hides inside a string
+// field whose surrounding structure never changed — so it is checked on every
+// file, not only on ones that failed to parse as the current shape.
+//
+// It reports whether anything changed, so a caller can gate writing the result
+// behind a flag while still surfacing that a file is stale.
+//
+// Staleness is decided by content alone: $schema is an editor hint, not part of
+// the format, and nothing in the CLI reads it to parse, validate or dispatch. A
+// migrated file does get its $schema pointed at SchemaURL, since the file
+// really did change.
 //
 // Once a file IS stale, the rewrite re-marshals the whole struct, so it also
 // canonicalizes formatting to match what the rest of the CLI generates (e.g.
@@ -25,7 +33,9 @@ func MigrateSpecsContent(raw []byte) (out []byte, changed bool, err error) {
 		return nil, false, err
 	}
 
-	if !structureChanged {
+	colorsDecoded := decodeLegacyColors(&specs)
+
+	if !structureChanged && !colorsDecoded {
 		return raw, false, nil
 	}
 

--- a/internal/specs_format/migrate_test.go
+++ b/internal/specs_format/migrate_test.go
@@ -2,8 +2,10 @@ package specs_format_test
 
 import (
 	"encoding/json"
+	"math/big"
 	"testing"
 
+	"github.com/formancehq/numscript/internal/interpreter"
 	"github.com/formancehq/numscript/internal/specs_format"
 	"github.com/stretchr/testify/require"
 )
@@ -73,5 +75,81 @@ func TestMigrateSpecsContentStaleSchema(t *testing.T) {
 
 func TestMigrateSpecsContentParseErr(t *testing.T) {
 	_, _, err := specs_format.MigrateSpecsContent([]byte("not json"))
+	require.Error(t, err)
+}
+
+// TestMigrateSpecsContentLegacyV0024Shape uses the exact specs shape v0.0.24
+// (commit 1b42b98, the last tagged release) generated: balances and metadata
+// as nested maps rather than today's row arrays.
+func TestMigrateSpecsContentLegacyV0024Shape(t *testing.T) {
+	raw := []byte(`{
+  "testCases": [
+    {
+      "it": "-",
+      "balances": {
+        "sales:042": { "EUR/2": 2500 },
+        "users:053": { "EUR/2": 500 }
+      },
+      "variables": { "sale": "sales:042" },
+      "metadata": {
+        "sales:042": { "seller": "users:053" },
+        "users:053": { "commission": "12.5%" }
+      },
+      "expect.metadata": {
+        "sales:042": { "paid": "true" }
+      },
+      "expect.txMetadata": { "note": "payout" },
+      "expect.postings": [
+        { "source": "sales:042", "destination": "users:053", "amount": 88, "asset": "EUR/2" }
+      ]
+    }
+  ]
+}
+`)
+
+	out, changed, err := specs_format.MigrateSpecsContent(raw)
+	require.NoError(t, err)
+	require.True(t, changed)
+
+	var specs specs_format.Specs
+	require.NoError(t, json.Unmarshal(out, &specs))
+	require.Equal(t, specs_format.SchemaURL, specs.Schema)
+
+	tc := specs.TestCases[0]
+	require.ElementsMatch(t, interpreter.Balances{
+		{Account: "sales:042", Asset: "EUR/2", Amount: big.NewInt(2500)},
+		{Account: "users:053", Asset: "EUR/2", Amount: big.NewInt(500)},
+	}, tc.Balances)
+	require.Equal(t, interpreter.VariablesMap{"sale": "sales:042"}, tc.Vars)
+	require.ElementsMatch(t, interpreter.AccountsMetadata{
+		{Account: "sales:042", Key: "seller", Value: "users:053"},
+		{Account: "users:053", Key: "commission", Value: "12.5%"},
+	}, tc.Meta)
+	require.Equal(t, interpreter.SetAccountsMetadata{
+		{Account: "sales:042", Key: "paid", Value: "true"},
+	}, tc.ExpectAccountsMeta)
+	require.Equal(t, specs_format.ExpectedTxMeta{
+		{Key: "note", Value: "payout"},
+	}, tc.ExpectTxMeta)
+	require.Len(t, tc.ExpectPostings, 1)
+}
+
+func TestMigrateSpecsContentUnsupportedShapeStillErrors(t *testing.T) {
+	// The fadd1f8 tagged-metadata-value format: never released, and distinct
+	// from v0.0.24's shape (whose leaf values are plain strings), so it
+	// should still fail rather than silently "succeed" as a legacy parse.
+	raw := []byte(`{
+  "testCases": [
+    {
+      "it": "d1",
+      "expect.metadata": [
+        { "account": "acc", "key": "k", "value": {"type": "monetary", "asset": "USD/2", "amount": "100"} }
+      ]
+    }
+  ]
+}
+`)
+
+	_, _, err := specs_format.MigrateSpecsContent(raw)
 	require.Error(t, err)
 }

--- a/internal/specs_format/migrate_test.go
+++ b/internal/specs_format/migrate_test.go
@@ -1,0 +1,77 @@
+package specs_format_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/formancehq/numscript/internal/specs_format"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMigrateSpecsContentAlreadyCurrent(t *testing.T) {
+	raw := []byte(`{
+  "$schema": "` + specs_format.SchemaURL + `",
+  "testCases": [
+    {
+      "it": "d1",
+      "expect.metadata": [
+        { "account": "acc", "key": "k", "value": "USD/2 100" }
+      ]
+    }
+  ]
+}
+`)
+
+	out, changed, err := specs_format.MigrateSpecsContent(raw)
+	require.NoError(t, err)
+	require.False(t, changed)
+
+	// re-marshaling is still idempotent, even though nothing was reported changed
+	var specs specs_format.Specs
+	require.NoError(t, json.Unmarshal(out, &specs))
+	require.Equal(t, specs_format.SchemaURL, specs.Schema)
+}
+
+func TestMigrateSpecsContentMissingSchema(t *testing.T) {
+	raw := []byte(`{
+  "testCases": [
+    {
+      "it": "d1",
+      "expect.metadata": [
+        { "account": "acc", "key": "k", "value": "USD/2 100" }
+      ]
+    }
+  ]
+}
+`)
+
+	out, changed, err := specs_format.MigrateSpecsContent(raw)
+	require.NoError(t, err)
+	require.True(t, changed)
+
+	var specs specs_format.Specs
+	require.NoError(t, json.Unmarshal(out, &specs))
+	require.Equal(t, specs_format.SchemaURL, specs.Schema)
+	require.Equal(t, "USD/2 100", specs.TestCases[0].ExpectAccountsMeta[0].Value)
+}
+
+func TestMigrateSpecsContentStaleSchema(t *testing.T) {
+	raw := []byte(`{
+  "$schema": "https://raw.githubusercontent.com/formancehq/numscript/main/specs.schema.json",
+  "testCases": [{ "it": "d1" }]
+}
+`)
+
+	out, changed, err := specs_format.MigrateSpecsContent(raw)
+	require.NoError(t, err)
+	require.True(t, changed)
+
+	var specs specs_format.Specs
+	require.NoError(t, json.Unmarshal(out, &specs))
+	require.Equal(t, specs_format.SchemaURL, specs.Schema)
+}
+
+func TestMigrateSpecsContentParseErr(t *testing.T) {
+	_, _, err := specs_format.MigrateSpecsContent([]byte("not json"))
+	require.Error(t, err)
+}

--- a/internal/specs_format/migrate_test.go
+++ b/internal/specs_format/migrate_test.go
@@ -143,3 +143,117 @@ func TestMigrateSpecsContentUnsupportedShapeStillErrors(t *testing.T) {
 	_, _, err := specs_format.MigrateSpecsContent(raw)
 	require.Error(t, err)
 }
+
+// A v0.0.24 file that used colors but no nested balance/metadata maps parses
+// cleanly as the current shape, so the encoded assets are the only thing left
+// to migrate. This is the case the structural check alone can't catch.
+func TestMigrateSpecsContentDecodesColorsInCurrentShape(t *testing.T) {
+	raw := []byte(`{
+  "featureFlags": ["experimental-asset-colors"],
+  "balances": [
+    { "account": "acc", "asset": "COIN_RED", "amount": 1 }
+  ],
+  "testCases": [
+    {
+      "it": "-",
+      "expect.postings": [
+        { "source": "src", "destination": "dest", "amount": 10, "asset": "USD_COL/4" }
+      ],
+      "expect.movements": [
+        { "source": "src", "destination": "dest", "amount": 10, "asset": "USD_COL/4" }
+      ],
+      "expect.endBalances": [
+        { "account": "dest", "asset": "USD_COL/4", "amount": 10 }
+      ]
+    }
+  ]
+}
+`)
+
+	out, changed, err := specs_format.MigrateSpecsContent(raw)
+	require.NoError(t, err)
+	require.True(t, changed)
+
+	var specs specs_format.Specs
+	require.NoError(t, json.Unmarshal(out, &specs))
+
+	require.Equal(t, interpreter.Balances{
+		{Account: "acc", Asset: "COIN", Color: "RED", Amount: big.NewInt(1)},
+	}, specs.Balances)
+
+	tc := specs.TestCases[0]
+	require.Equal(t, "USD/4", tc.ExpectPostings[0].Asset)
+	require.Equal(t, "COL", tc.ExpectPostings[0].Color)
+	require.Equal(t, "USD/4", tc.ExpectMovements[0].Asset)
+	require.Equal(t, "COL", tc.ExpectMovements[0].Color)
+	require.Equal(t, "USD/4", tc.ExpectEndBalances[0].Asset)
+	require.Equal(t, "COL", tc.ExpectEndBalances[0].Color)
+}
+
+// Both migrations at once: the nested-map structure AND encoded assets inside it.
+func TestMigrateSpecsContentDecodesColorsInLegacyShape(t *testing.T) {
+	raw := []byte(`{
+  "testCases": [
+    {
+      "it": "-",
+      "balances": { "acc": { "COIN_RED": 1, "COIN": 100 } }
+    }
+  ]
+}
+`)
+
+	out, changed, err := specs_format.MigrateSpecsContent(raw)
+	require.NoError(t, err)
+	require.True(t, changed)
+
+	var specs specs_format.Specs
+	require.NoError(t, json.Unmarshal(out, &specs))
+
+	require.ElementsMatch(t, interpreter.Balances{
+		{Account: "acc", Asset: "COIN", Amount: big.NewInt(100)},
+		{Account: "acc", Asset: "COIN", Color: "RED", Amount: big.NewInt(1)},
+	}, specs.TestCases[0].Balances)
+}
+
+// A row that already carries a color can't be a legacy row, so it is left
+// exactly as-is — including its asset, however odd it looks.
+func TestMigrateSpecsContentLeavesExplicitColorAlone(t *testing.T) {
+	raw := []byte(`{
+  "balances": [
+    { "account": "acc", "asset": "COIN_RED", "color": "BLUE", "amount": 1 }
+  ]
+}
+`)
+
+	out, changed, err := specs_format.MigrateSpecsContent(raw)
+	require.NoError(t, err)
+	require.False(t, changed)
+	require.Equal(t, raw, out)
+}
+
+// Assets that merely resemble the encoding must not be split: the separator is
+// a single underscore between an asset name and a [A-Z]{1,16} color.
+func TestMigrateSpecsContentLeavesNonEncodedAssetsAlone(t *testing.T) {
+	for _, asset := range []string{
+		"USD/2",     // no underscore at all
+		"COIN",      // ditto
+		"USD_",      // empty color
+		"USD_red/2", // colors are upper-case
+		"USD_A_B",   // two separators
+		"_RED",      // empty asset name
+	} {
+		t.Run(asset, func(t *testing.T) {
+			raw := []byte(`{
+  "balances": [
+    { "account": "acc", "asset": "` + asset + `", "amount": 1 }
+  ]
+}
+`)
+
+			out, changed, err := specs_format.MigrateSpecsContent(raw)
+			require.NoError(t, err)
+			require.False(t, changed)
+			require.Equal(t, raw, out)
+		})
+	}
+}

--- a/internal/specs_format/migrate_test.go
+++ b/internal/specs_format/migrate_test.go
@@ -27,15 +27,20 @@ func TestMigrateSpecsContentAlreadyCurrent(t *testing.T) {
 	out, changed, err := specs_format.MigrateSpecsContent(raw)
 	require.NoError(t, err)
 	require.False(t, changed)
-
-	// re-marshaling is still idempotent, even though nothing was reported changed
-	var specs specs_format.Specs
-	require.NoError(t, json.Unmarshal(out, &specs))
-	require.Equal(t, specs_format.SchemaURL, specs.Schema)
+	require.Equal(t, raw, out)
 }
 
-func TestMigrateSpecsContentMissingSchema(t *testing.T) {
-	raw := []byte(`{
+// $schema is an editor hint, not part of the format: a file whose structure is
+// already current is left byte-for-byte alone, whatever its $schema says.
+func TestMigrateSpecsContentLeavesSchemaAlone(t *testing.T) {
+	for name, schemaLine := range map[string]string{
+		"missing":      "",
+		"stale":        `"$schema": "https://raw.githubusercontent.com/formancehq/numscript/main/specs.schema.json",`,
+		"foreign host": `"$schema": "https://example.invalid/v1.specs.schema.json",`,
+	} {
+		t.Run(name, func(t *testing.T) {
+			raw := []byte(`{
+  ` + schemaLine + `
   "testCases": [
     {
       "it": "d1",
@@ -47,30 +52,12 @@ func TestMigrateSpecsContentMissingSchema(t *testing.T) {
 }
 `)
 
-	out, changed, err := specs_format.MigrateSpecsContent(raw)
-	require.NoError(t, err)
-	require.True(t, changed)
-
-	var specs specs_format.Specs
-	require.NoError(t, json.Unmarshal(out, &specs))
-	require.Equal(t, specs_format.SchemaURL, specs.Schema)
-	require.Equal(t, "USD/2 100", specs.TestCases[0].ExpectAccountsMeta[0].Value)
-}
-
-func TestMigrateSpecsContentStaleSchema(t *testing.T) {
-	raw := []byte(`{
-  "$schema": "https://raw.githubusercontent.com/formancehq/numscript/main/specs.schema.json",
-  "testCases": [{ "it": "d1" }]
-}
-`)
-
-	out, changed, err := specs_format.MigrateSpecsContent(raw)
-	require.NoError(t, err)
-	require.True(t, changed)
-
-	var specs specs_format.Specs
-	require.NoError(t, json.Unmarshal(out, &specs))
-	require.Equal(t, specs_format.SchemaURL, specs.Schema)
+			out, changed, err := specs_format.MigrateSpecsContent(raw)
+			require.NoError(t, err)
+			require.False(t, changed)
+			require.Equal(t, raw, out)
+		})
+	}
 }
 
 func TestMigrateSpecsContentParseErr(t *testing.T) {
@@ -113,6 +100,9 @@ func TestMigrateSpecsContentLegacyV0024Shape(t *testing.T) {
 
 	var specs specs_format.Specs
 	require.NoError(t, json.Unmarshal(out, &specs))
+
+	// a structural migration does point $schema at the current schema: the
+	// file's shape really did change.
 	require.Equal(t, specs_format.SchemaURL, specs.Schema)
 
 	tc := specs.TestCases[0]

--- a/internal/specs_format/migrate_v0024.go
+++ b/internal/specs_format/migrate_v0024.go
@@ -1,0 +1,193 @@
+package specs_format
+
+import (
+	"encoding/json"
+	"math/big"
+	"sort"
+
+	"github.com/formancehq/numscript/internal/interpreter"
+)
+
+// The types below mirror the specs format as it shipped in v0.0.24 (commit
+// 1b42b98), the last tagged release before balances and metadata became row
+// arrays instead of nested maps (see interpreter.Balances / AccountsMetadata
+// history). A real, released specs file can be in this shape, unlike the
+// short-lived tagged-metadata-value format from fadd1f8, which was never
+// released and isn't supported here.
+//
+// Known gap: v0.0.24 encoded an asset's color into its name (e.g. "USD_RED"),
+// rather than as today's separate Color field. This conversion carries that
+// name through as-is rather than trying to decode it, since the two can't be
+// told apart from the string alone (a real asset might just contain an
+// underscore). A file that relied on colored assets needs a manual fix after
+// migrating.
+type legacyV0024Balances map[string]map[string]*big.Int
+
+type legacyV0024AccountsMetadata map[string]map[string]string
+
+type legacyV0024Specs struct {
+	Schema       string                      `json:"$schema,omitempty"`
+	FeatureFlags []string                    `json:"featureFlags,omitempty"`
+	Balances     legacyV0024Balances         `json:"balances,omitempty"`
+	Vars         interpreter.VariablesMap    `json:"variables,omitempty"`
+	Meta         legacyV0024AccountsMetadata `json:"metadata,omitempty"`
+	TestCases    []legacyV0024TestCase       `json:"testCases,omitempty"`
+}
+
+type legacyV0024TestCase struct {
+	It string `json:"it"`
+
+	Balances legacyV0024Balances         `json:"balances,omitempty"`
+	Vars     interpreter.VariablesMap    `json:"variables,omitempty"`
+	Meta     legacyV0024AccountsMetadata `json:"metadata,omitempty"`
+
+	Focus bool `json:"focus,omitempty"`
+	Skip  bool `json:"skip,omitempty"`
+
+	ExpectMissingFunds   bool `json:"expect.error.missingFunds,omitempty"`
+	ExpectNegativeAmount bool `json:"expect.error.negativeAmount,omitempty"`
+
+	// These three didn't change shape between v0.0.24 and today (new fields
+	// were all added as omitempty), so they unmarshal directly into the
+	// current types.
+	ExpectPostings  []interpreter.Posting `json:"expect.postings,omitempty"`
+	ExpectMovements Movements             `json:"expect.movements,omitempty"`
+
+	ExpectTxMeta             map[string]string           `json:"expect.txMetadata,omitempty"`
+	ExpectAccountsMeta       legacyV0024AccountsMetadata `json:"expect.metadata,omitempty"`
+	ExpectEndBalances        legacyV0024Balances         `json:"expect.endBalances,omitempty"`
+	ExpectEndBalancesInclude legacyV0024Balances         `json:"expect.endBalances.include,omitempty"`
+}
+
+// parseLegacyV0024Specs reports whether raw parses as a v0.0.24-shaped specs
+// file. Only called after the current Specs shape has already failed to
+// parse, so this is the fallback path, not the common case.
+func parseLegacyV0024Specs(raw []byte) (legacyV0024Specs, bool) {
+	var legacy legacyV0024Specs
+	if err := json.Unmarshal(raw, &legacy); err != nil {
+		return legacyV0024Specs{}, false
+	}
+	return legacy, true
+}
+
+func upgradeLegacyV0024Specs(legacy legacyV0024Specs) Specs {
+	testCases := make([]TestCase, 0, len(legacy.TestCases))
+	for _, tc := range legacy.TestCases {
+		testCases = append(testCases, TestCase{
+			It:                       tc.It,
+			Balances:                 upgradeLegacyBalances(tc.Balances),
+			Vars:                     tc.Vars,
+			Meta:                     upgradeLegacyAccountsMetadata(tc.Meta),
+			Focus:                    tc.Focus,
+			Skip:                     tc.Skip,
+			ExpectMissingFunds:       tc.ExpectMissingFunds,
+			ExpectNegativeAmount:     tc.ExpectNegativeAmount,
+			ExpectPostings:           tc.ExpectPostings,
+			ExpectTxMeta:             upgradeLegacyTxMeta(tc.ExpectTxMeta),
+			ExpectAccountsMeta:       upgradeLegacySetAccountsMetadata(tc.ExpectAccountsMeta),
+			ExpectEndBalances:        upgradeLegacyBalances(tc.ExpectEndBalances),
+			ExpectEndBalancesInclude: upgradeLegacyBalances(tc.ExpectEndBalancesInclude),
+			ExpectMovements:          tc.ExpectMovements,
+		})
+	}
+
+	return Specs{
+		Schema:       legacy.Schema,
+		FeatureFlags: legacy.FeatureFlags,
+		Balances:     upgradeLegacyBalances(legacy.Balances),
+		Vars:         legacy.Vars,
+		Meta:         upgradeLegacyAccountsMetadata(legacy.Meta),
+		TestCases:    testCases,
+	}
+}
+
+// upgradeLegacyBalances flattens {account: {asset: amount}} into sorted rows,
+// so the migrated file's diff is deterministic across runs.
+func upgradeLegacyBalances(legacy legacyV0024Balances) interpreter.Balances {
+	if legacy == nil {
+		return nil
+	}
+	rows := make(interpreter.Balances, 0, len(legacy))
+	for account, byAsset := range legacy {
+		for asset, amount := range byAsset {
+			rows = append(rows, interpreter.BalanceRow{
+				Account: account,
+				Asset:   asset,
+				Amount:  amount,
+			})
+		}
+	}
+	sort.Slice(rows, func(i, j int) bool {
+		if rows[i].Account != rows[j].Account {
+			return rows[i].Account < rows[j].Account
+		}
+		return rows[i].Asset < rows[j].Asset
+	})
+	return rows
+}
+
+// upgradeLegacyAccountsMetadata flattens {account: {key: value}} into sorted
+// rows, the same way upgradeLegacyBalances does.
+func upgradeLegacyAccountsMetadata(legacy legacyV0024AccountsMetadata) interpreter.AccountsMetadata {
+	if legacy == nil {
+		return nil
+	}
+	rows := make(interpreter.AccountsMetadata, 0, len(legacy))
+	for account, byKey := range legacy {
+		for key, value := range byKey {
+			rows = append(rows, interpreter.AccountMetadataRow{
+				Account: account,
+				Key:     key,
+				Value:   value,
+			})
+		}
+	}
+	sort.Slice(rows, func(i, j int) bool {
+		if rows[i].Account != rows[j].Account {
+			return rows[i].Account < rows[j].Account
+		}
+		return rows[i].Key < rows[j].Key
+	})
+	return rows
+}
+
+// upgradeLegacySetAccountsMetadata is upgradeLegacyAccountsMetadata's
+// counterpart for expect.metadata, whose row type carries an extra Scope
+// field the legacy shape never had (scopes didn't exist in v0.0.24).
+func upgradeLegacySetAccountsMetadata(legacy legacyV0024AccountsMetadata) interpreter.SetAccountsMetadata {
+	if legacy == nil {
+		return nil
+	}
+	rows := make(interpreter.SetAccountsMetadata, 0, len(legacy))
+	for account, byKey := range legacy {
+		for key, value := range byKey {
+			rows = append(rows, interpreter.SetAccountMetadataRow{
+				Account: account,
+				Key:     key,
+				Value:   value,
+			})
+		}
+	}
+	sort.Slice(rows, func(i, j int) bool {
+		if rows[i].Account != rows[j].Account {
+			return rows[i].Account < rows[j].Account
+		}
+		return rows[i].Key < rows[j].Key
+	})
+	return rows
+}
+
+// upgradeLegacyTxMeta flattens {key: value} into sorted rows.
+func upgradeLegacyTxMeta(legacy map[string]string) ExpectedTxMeta {
+	if legacy == nil {
+		return nil
+	}
+	rows := make(ExpectedTxMeta, 0, len(legacy))
+	for key, value := range legacy {
+		rows = append(rows, TxMetadataRow{Key: key, Value: value})
+	}
+	sort.Slice(rows, func(i, j int) bool {
+		return rows[i].Key < rows[j].Key
+	})
+	return rows
+}

--- a/internal/specs_format/migrate_v0024.go
+++ b/internal/specs_format/migrate_v0024.go
@@ -3,6 +3,7 @@ package specs_format
 import (
 	"encoding/json"
 	"math/big"
+	"regexp"
 	"sort"
 
 	"github.com/formancehq/numscript/internal/interpreter"
@@ -15,12 +16,9 @@ import (
 // short-lived tagged-metadata-value format from fadd1f8, which was never
 // released and isn't supported here.
 //
-// Known gap: v0.0.24 encoded an asset's color into its name (e.g. "USD_RED"),
-// rather than as today's separate Color field. This conversion carries that
-// name through as-is rather than trying to decode it, since the two can't be
-// told apart from the string alone (a real asset might just contain an
-// underscore). A file that relied on colored assets needs a manual fix after
-// migrating.
+// v0.0.24 also encoded an asset's color into its name (e.g. "USD_COL/4" for
+// asset USD/4 colored COL) rather than as today's separate Color field; see
+// decodeLegacyColors below for how that is undone.
 type legacyV0024Balances map[string]map[string]*big.Int
 
 type legacyV0024AccountsMetadata map[string]map[string]string
@@ -190,4 +188,98 @@ func upgradeLegacyTxMeta(legacy map[string]string) ExpectedTxMeta {
 		return rows[i].Key < rows[j].Key
 	})
 	return rows
+}
+
+// legacyColoredAssetRegexp matches v0.0.24's ASSET_COLOR encoding, splitting it
+// into the asset's base name, the color, and the optional precision suffix.
+//
+// The match is unambiguous: an asset name can't contain an underscore (the
+// lexer's ASSET token doesn't allow one, and interpreter.checkAssetName
+// rejects it), so an underscore here can only be the encoding's separator. The
+// two halves are constrained to the same shapes the interpreter accepts today
+// for an asset and a color respectively.
+var legacyColoredAssetRegexp = regexp.MustCompile(`^([A-Z][A-Z0-9]{0,16})_([A-Z]{1,16})(\/\d{1,6})?$`)
+
+// splitLegacyColoredAsset undoes the ASSET_COLOR encoding, reporting whether
+// src was encoded at all. v0.0.24 inserted the color before the precision
+// suffix, so "USD/4" colored "COL" became "USD_COL/4".
+func splitLegacyColoredAsset(src string) (asset string, color string, ok bool) {
+	m := legacyColoredAssetRegexp.FindStringSubmatch(src)
+	if m == nil {
+		return src, "", false
+	}
+	return m[1] + m[3], m[2], true
+}
+
+// decodeLegacyColors rewrites every ASSET_COLOR-encoded asset in specs into the
+// separate asset/color fields colors became in cbc11e8, reporting whether
+// anything changed.
+//
+// Unlike the rest of this file, this runs on every specs file rather than only
+// on ones that failed to parse as the current shape. The encoding lives inside
+// a string field whose surrounding structure never changed, so a v0.0.24 file
+// that used colors but no nested balance/metadata maps parses cleanly as the
+// current shape and would otherwise never be offered for decoding.
+//
+// A row that already carries a Color is left alone: it can't be a legacy row,
+// and overwriting it would lose information.
+func decodeLegacyColors(specs *Specs) bool {
+	changed := decodeBalanceColors(specs.Balances)
+	for i := range specs.TestCases {
+		tc := &specs.TestCases[i]
+		changed = decodeBalanceColors(tc.Balances) || changed
+		changed = decodeBalanceColors(tc.ExpectEndBalances) || changed
+		changed = decodeBalanceColors(tc.ExpectEndBalancesInclude) || changed
+		changed = decodePostingColors(tc.ExpectPostings) || changed
+		changed = decodeMovementColors(tc.ExpectMovements) || changed
+	}
+	return changed
+}
+
+func decodeBalanceColors(rows interpreter.Balances) bool {
+	changed := false
+	for i := range rows {
+		if rows[i].Color != "" {
+			continue
+		}
+		asset, color, ok := splitLegacyColoredAsset(rows[i].Asset)
+		if !ok {
+			continue
+		}
+		rows[i].Asset, rows[i].Color = asset, color
+		changed = true
+	}
+	return changed
+}
+
+func decodePostingColors(postings []interpreter.Posting) bool {
+	changed := false
+	for i := range postings {
+		if postings[i].Color != "" {
+			continue
+		}
+		asset, color, ok := splitLegacyColoredAsset(postings[i].Asset)
+		if !ok {
+			continue
+		}
+		postings[i].Asset, postings[i].Color = asset, color
+		changed = true
+	}
+	return changed
+}
+
+func decodeMovementColors(movements Movements) bool {
+	changed := false
+	for i := range movements {
+		if movements[i].Color != "" {
+			continue
+		}
+		asset, color, ok := splitLegacyColoredAsset(movements[i].Asset)
+		if !ok {
+			continue
+		}
+		movements[i].Asset, movements[i].Color = asset, color
+		changed = true
+	}
+	return changed
 }

--- a/numscript_test.go
+++ b/numscript_test.go
@@ -455,7 +455,7 @@ set_tx_meta(
 	require.Nil(t, err)
 
 	require.Equal(t, interpreter.Metadata{
-		"k": interpreter.NewMonetary("USD/2", 100),
+		"k": "USD/2 100",
 	}, res.Metadata)
 
 	require.Equal(t,

--- a/v1.specs.schema.json
+++ b/v1.specs.schema.json
@@ -78,6 +78,10 @@
 
         "expect.error.missingFunds": {
           "type": "boolean"
+        },
+
+        "expect.error.negativeAmount": {
+          "type": "boolean"
         }
       }
     },
@@ -156,13 +160,13 @@
 
     "SetAccountsMetadata": {
       "type": "array",
-      "description": "List of account metadata entries set during execution. Each value is a tagged value.",
+      "description": "List of account metadata entries set during execution. The (account, key, scope) tuple of each entry must be unique within the list.",
       "items": { "$ref": "#/definitions/SetAccountMetadataRow" }
     },
 
     "SetAccountMetadataRow": {
       "type": "object",
-      "description": "A single set metadata entry: the tagged value of a given (account, key, scope)",
+      "description": "A single set metadata entry: the value of a given (account, key, scope)",
       "additionalProperties": false,
       "required": ["account", "key", "value"],
       "properties": {
@@ -174,7 +178,7 @@
           "type": "string"
         },
         "value": {
-          "$ref": "#/definitions/Value"
+          "$ref": "#/definitions/MetaValue"
         },
         "scope": {
           "type": "string",
@@ -191,7 +195,7 @@
 
     "TxMetadataRow": {
       "type": "object",
-      "description": "A single transaction metadata entry: the tagged value of a given key",
+      "description": "A single transaction metadata entry: the value of a given key",
       "additionalProperties": false,
       "required": ["key", "value"],
       "properties": {
@@ -199,67 +203,14 @@
           "type": "string"
         },
         "value": {
-          "$ref": "#/definitions/Value"
+          "$ref": "#/definitions/MetaValue"
         }
       }
     },
 
-    "Value": {
-      "type": "object",
-      "description": "A tagged value, discriminated by its \"type\"",
-      "oneOf": [
-        {
-          "additionalProperties": false,
-          "required": ["type", "value"],
-          "properties": {
-            "type": { "const": "string" },
-            "value": { "type": "string" }
-          }
-        },
-        {
-          "additionalProperties": false,
-          "required": ["type", "value"],
-          "properties": {
-            "type": { "const": "number" },
-            "value": { "type": "string", "pattern": "^-?[0-9]+$" }
-          }
-        },
-        {
-          "additionalProperties": false,
-          "required": ["type", "name"],
-          "properties": {
-            "type": { "const": "asset" },
-            "name": { "type": "string", "pattern": "^([A-Z]+(/[0-9]+)?)$" }
-          }
-        },
-        {
-          "additionalProperties": false,
-          "required": ["type", "name"],
-          "properties": {
-            "type": { "const": "account" },
-            "name": { "type": "string", "pattern": "^([a-zA-Z0-9_-]+(:[a-zA-Z0-9_-]+)*)$" },
-            "scope": { "type": "string", "pattern": "^[a-z0-9_]*$" }
-          }
-        },
-        {
-          "additionalProperties": false,
-          "required": ["type", "asset", "amount"],
-          "properties": {
-            "type": { "const": "monetary" },
-            "asset": { "type": "string", "pattern": "^([A-Z]+(/[0-9]+)?)$" },
-            "amount": { "type": "string", "pattern": "^-?[0-9]+$" }
-          }
-        },
-        {
-          "additionalProperties": false,
-          "required": ["type", "numerator", "denominator"],
-          "properties": {
-            "type": { "const": "portion" },
-            "numerator": { "type": "string", "pattern": "^-?[0-9]+$" },
-            "denominator": { "type": "string", "pattern": "^-?[0-9]+$" }
-          }
-        }
-      ]
+    "MetaValue": {
+      "type": "string",
+      "description": "A metadata value, as rendered in source form: a string as-is (abc), an account as its bare name (alice), an asset (COIN, USD/2), a number (42, -7), a monetary (USD/2 100), or a portion (1/2). The format is untyped: values of different types that render alike are not distinguished."
     },
 
     "Movements": {


### PR DESCRIPTION
## `numscript test --migrate`

Specs files written against older numscript versions no longer parse — `test` just fails with a JSON error. This adds a flag that rewrites them for you, then runs the tests on the updated content in the same pass.

```console
$ numscript test ./examples
Error: examples/main.num.specs.json
json: cannot unmarshal object into Go struct field Specs.balances of type interpreter.Balances

$ numscript test --migrate ./examples
↻ migrated examples/main.num.specs.json
✓ examples/main.num (1 tests)
```

Opt-in: without the flag, `test` never touches your files.

It fixes two things:

**The `v0.0.24` layout**, where balances and metadata were objects keyed by account, into today's row arrays:

```json
// before
"balances": { "world": { "USD/2": 0 } }

// after
"balances": [{ "account": "world", "asset": "USD/2", "amount": 0 }]
```

**A missing or outdated `$schema`**, pointed at the current one.

Files that are already current are left byte-for-byte untouched. Files that aren't get fully reformatted to match what `test-init` generates.

Known gap: `v0.0.24` encoded asset colors into the name (`USD_RED`). That can't be told apart from an asset name containing an underscore, so it's carried through unchanged and needs a manual fix.

## Metadata values are plain strings again

Reverts the unreleased tagged-value format. Values are now written as you'd write them in source:

```json
// before
{ "key": "portion", "value": { "type": "portion", "numerator": "3", "denominator": "25" } }

// after
{ "key": "portion", "value": "3/25" }
```

Metadata is untyped, so `set_tx_meta("k", "42")` and `set_tx_meta("k", 42)` are the same thing. Since the tagged format was never released, the migration tool targets `v0.0.24` instead.

## Also

- Schema documents `expect.error.negativeAmount` (already supported in code).
- The repo's own `testdata` was regenerated with the tool — that's most of the diff.
- Tests: unit tests for the migration cases, plus e2e tests that build and exec the real binary.
