### PR TITLE
fix: replace deprecated goreleaser archives.format with formats

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -29,13 +29,13 @@ builds:
       - -X main.Version=v{{ .Version }}
 
 archives:
-  - format: tar.gz
+  - formats: [tar.gz]
     # this name template makes the OS and Arch compatible with the results of `uname`.
     name_template: '{{ .ProjectName }}_{{ .Version }}_{{ title .Os }}_{{ if eq .Arch "amd64" }}x86_64{{ else if eq .Arch "386" }}i386{{ else }}{{ .Arch }}{{ end }}{{ if .Arm }}v{{ .Arm }}{{ end }}'
     # use zip for windows archives
     format_overrides:
       - goos: windows
-        format: zip
+        formats: [zip]
 
 changelog:
   sort: asc


### PR DESCRIPTION
GoReleaser warns on every release:

```
DEPRECATED: archives.format should not be used anymore
DEPRECATED: archives.format_overrides.format should not be used anymore
```

Switches both to the `formats` list form. `goreleaser check` passes with no warnings; archive names and extensions are unchanged.